### PR TITLE
Include BC in dice EDGAR v12 5 0

### DIFF
--- a/runs/shared_inputs/aerosol/HEMCO_Config.template
+++ b/runs/shared_inputs/aerosol/HEMCO_Config.template
@@ -6,18 +6,18 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
 # !REMARKS:
-#  Customized for the offline aerosol simulation. 
+#  Customized for the offline aerosol simulation.
 #
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -26,8 +26,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -57,11 +57,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -72,17 +72,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -100,7 +100,7 @@ Warnings:                    {WARNINGS}
     --> NEI2011_SHIP_HOURLY    :       false
     --> NEI2011_SHIP_MONMEAN   :       false
     --> MIX                    :       true
-    --> DICE_Africa            :       true 
+    --> DICE_Africa            :       true
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -112,7 +112,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -128,19 +128,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
-    --> Emit Br2               :       false  
-    --> Br2 scaling            :       1.0 
+    --> Emit Br2               :       false
+    --> Br2 scaling            :       1.0
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -171,14 +171,14 @@ Warnings:                    {WARNINGS}
     --> hydrophilic BC         :       0.2
     --> hydrophilic OC         :       0.5
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : off   MOPO/MOPI 
+116     MarinePOA              : off   MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -390,27 +390,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280     1 60
 0 DICE_CARS_SO2   $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  SO2     2013/1/1/0 C xy g/m2/yr  SO2   31/78/1008      1 60
@@ -422,7 +422,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      1 60
 0 DICE_MOTORCYCLES_SO2   $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  SO2    2013/1/1/0 C xy g/m2/yr  SO2   31/78/1008       1 60
@@ -434,7 +434,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      1 60
 0 DICE_BACKUPGEN_SO2   $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  SO2  2013/1/1/0 C xy g/m2/yr  SO2   31/78/1008       1 60
@@ -446,7 +446,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280/320  1 60
 0 DICE_CHARCOALPROD_NH3   $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  NH3   2013/1/1/0 C xy g/m2/yr  NH3   1008/320         1 60
@@ -456,7 +456,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      1 60
 0 DICE_GASFLARE_BCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  BC    2013/1/1/0 C xy g/m2/yr  BCPI  70/1008          1 60
@@ -465,7 +465,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      2 60
 0 DICE_AGBURNING_SO2   $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  SO2   2013/1/1/0 C xy g/m2/yr  SO2   31/78/1008       2 60
@@ -478,7 +478,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      2 60
 0 DICE_CHARCOALUSE_NH3   $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  NH3   2013/1/1/0 C xy g/m2/yr  NH3   1008             2 60
@@ -488,7 +488,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      1 60
 0 DICE_KEROSENE_BCPI  $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  BC    2013/1/1/0 C xy g/m2/yr  BCPI  70/1008          1 60
@@ -497,7 +497,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      1 60
 0 DICE_OILREFINING_SO2   $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  SO2   2013/1/1/0 C xy g/m2/yr  SO2   31/78/1008       1 60
@@ -509,7 +509,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      2 60
 0 DICE_HOUSEFUELWOOD_SO2   $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  SO2   2013/1/1/0 C xy g/m2/yr  SO2   31/78/1008       2 60
@@ -522,7 +522,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_SOAP  $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  SOAP  26/1008/280      2 60
 0 DICE_OTHERFUELWOOD_SO2   $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  SO2   2013/1/1/0 C xy g/m2/yr  SO2   31/78/1008       2 60
@@ -682,10 +682,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -779,7 +779,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -921,11 +921,11 @@ Warnings:                    {WARNINGS}
 # ==> Now emit aircraft BC and OC into hydrophilic tracers BCPI and OCPI.
 #==============================================================================
 (((AEIC
-0 AEIC_SOAP $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_SOAP $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 )))AEIC
 
 #==============================================================================
@@ -939,7 +939,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_NH3  $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_NH3_2005-2100_23474.nc ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NH3  -   1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_SOAP  $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  SOAP 280 1 1
 0 RCP45_BCPO  $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_BC_2005-2100_27424.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  BCPO -   1 1
 0 RCP45_OCPO  $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_OC_2005-2100_27424.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  OCPO -   1 1
@@ -947,7 +947,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_NH3   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NH3_2005-2100_27424.nc  ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NH3  -   1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_SOAP  $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  SOAP 280 1 1
 0 RCP60_BCPO  $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_BC_2005-2100_43190.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  BCPO -   1 1
 0 RCP60_OCPO  $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_OC_2005-2100_43190.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  OCPO -   1 1
@@ -955,7 +955,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_NH3   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NH3_2005-2100_43190.nc  ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NH3  -   1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_SOAP  $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  SOAP 280 1 1
 0 RCP85_BCPO  $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_BC_2005-2100_43533.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  BCPO -   1 1
 0 RCP85_OCPO  $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_OC_2005-2100_43533.nc   ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  OCPO -   1 1
@@ -967,20 +967,20 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_SOAP_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SOAP 54/75/281/311 5 2 
-0 QFED_SOAP_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SOAP 54/75/281/312 5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_SOAP_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SOAP 54/75/281/311 5 2
+0 QFED_SOAP_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SOAP 54/75/281/312 5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -1060,18 +1060,18 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
 # --- Seawater concentrations for oceanic emissions (Extension 101) ---
 #==============================================================================
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 
 #==============================================================================
 # --- Dust emissions using DEAD model (Extension 105) ---
@@ -1086,24 +1086,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -1144,7 +1144,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -1165,7 +1165,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -1188,10 +1188,10 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -1332,7 +1332,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -1620,20 +1620,20 @@ Warnings:                    {WARNINGS}
 # --- Inputs for the RRTMG radiative transfer model ---
 #
 # These fields will only be read if the +RRTMG+ toggle is activated.
-# +RRTMG+ can be set explicitly above as a setting of the base extension 
-# (--> +RRTMG+: true/false). If not defined, it will be set automatically 
+# +RRTMG+ can be set explicitly above as a setting of the base extension
+# (--> +RRTMG+: true/false). If not defined, it will be set automatically
 # based on the RRTMG toggle in input.geos (recommended).
 #
-# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce 
+# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce
 # differences at the level of numerical noise when comparing output to
 # simulations from prior versions (esp. when running at 4 x 5 resolution).
 # You might see larger differences w/r/t prior verisons for a few grid boxes
 # along the coastline of Antarctica, where the difference in resolution
-# and regridding will be more apparent in the sharp transition from ice to 
+# and regridding will be more apparent in the sharp transition from ice to
 # ocean.  If this is a problem, you can use the data files at 4x5 resolution
 # for 4x5 RRTMG simulations.
 #
-# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is 
+# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is
 # likely different than what was implemented when reading the old bpch
 # data from disk.  This can also cause differences when comparing to
 # prior versions.
@@ -1670,7 +1670,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -1707,7 +1707,7 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
@@ -1720,9 +1720,9 @@ Warnings:                    {WARNINGS}
 31 GEIA_SEASON_SO2  $ROOT/GEIA/v2014-07/GEIA_monthscal.generic.1x1.nc SO2rat 1985/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -1801,37 +1801,37 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 110 AEICNOCO 1.000000e-3 - -  - xy unitless 1
@@ -1854,11 +1854,11 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 265 NEI11_BC2BCPI     0.2                                           - -               - xy 1 1
 266 NEI11_BC2BCPO     0.8                                           - -               - xy 1 1
 267 NEI11_OC2OCPI     0.5                                           - -               - xy 1 1
@@ -1867,7 +1867,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -1891,7 +1891,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -1919,7 +1919,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.TOMAS
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.TOMAS
@@ -1007,6 +1007,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
+0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.TOMAS
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.TOMAS
@@ -6,9 +6,9 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
@@ -18,7 +18,7 @@
 #
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -27,8 +27,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -58,11 +58,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -73,17 +73,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -92,7 +92,7 @@ Warnings:                    {WARNINGS}
 # ExtNr ExtName                on/off  Species
 0       Base                   : on    *
 # ----- RESTART FIELDS ----------------------
-    --> GC_RESTART             :       true	
+    --> GC_RESTART             :       true
     --> HEMCO_RESTART          :       true
 # ----- REGIONAL INVENTORIES ----------------
     --> APEI                   :       true
@@ -101,7 +101,7 @@ Warnings:                    {WARNINGS}
     --> NEI2011_SHIP_HOURLY    :       false
     --> NEI2011_SHIP_MONMEAN   :       false
     --> MIX                    :       true
-    --> DICE_Africa            :       true 
+    --> DICE_Africa            :       true
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -118,7 +118,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -134,19 +134,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2
 102     ParaNOx                : on    NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
-104     SoilNOx                : off   NO 
+104     SoilNOx                : off   NO
     --> Use fertilizer NOx     :       true
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC/Br2/BrSALA/BrSALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
@@ -155,7 +155,7 @@ Warnings:                    {WARNINGS}
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -188,7 +188,7 @@ Warnings:                    {WARNINGS}
     --> hydrophilic OC         :       0.5
     --> FINN_subgrid_coag      :       false
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : off   MOPO/MOPI 
+116     MarinePOA              : off   MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
@@ -199,7 +199,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -705,27 +705,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  CO    26/1008         1 60
 0 DICE_CARS_SOAP  -                                                                 -       -          - -  -        SOAP  26/1008/280     1 60
@@ -751,7 +751,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_MOTORCYCLES_SOAP  -                                                                        -      -          - -  -        SOAP  26/1008/280      1 60
@@ -772,7 +772,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_BACKUPGEN_SOAP  -                                                                          -    -          - -  -        SOAP  26/1008/280      1 60
@@ -800,7 +800,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008/320      1 60
 0 DICE_CHARCOALPROD_SOAP  -                                                                                -     -          - -  -        SOAP  26/1008/280/320  1 60
@@ -821,7 +821,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_GASFLARE_SOAP  -                                                                       -     -          - -  -        SOAP  26/1008/280      1 60
@@ -839,7 +839,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_AGBURNING_SOAP  -                                                                                       -     -          - -  -        SOAP  26/1008/280      2 60
@@ -877,7 +877,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_CHARCOALUSE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      2 60
@@ -897,7 +897,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_KEROSENE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      1 60
@@ -907,7 +907,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_OILREFINING_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      1 60
@@ -932,7 +932,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_HOUSEFUELWOOD_SOAP  -                                                                                   -     -          - -  -        SOAP  26/1008/280      2 60
@@ -967,7 +967,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_OTHERFUELWOOD_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      2 60
@@ -1320,10 +1320,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -1460,7 +1460,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -1683,10 +1683,10 @@ Warnings:                    {WARNINGS}
 # NOTES:
 # - These C2H6 emissions are used in place of CEDS
 #==============================================================================
-(((C2H6_2010 
+(((C2H6_2010
 0 C2H6_2010_oilgas   $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc ANTHR_C2H6   2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
 0 C2H6_2010_biofuel  $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc BIOFUEL_C2H6 2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
-)))C2H6_2010 
+)))C2H6_2010
 
 #==============================================================================
 # --- Xiao et al., JGR, 2008 ---
@@ -1842,9 +1842,9 @@ Warnings:                    {WARNINGS}
 #------------------------------------------------------------------------------
 # ### IF THE PARANOX EXTENSION IS TURNED ON ###
 #
-# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension 
-# number (# 102) to specify these quantities and the NEI emissions.  
-# This will make sure everything will be passed to the HEMCO PARANOX extension 
+# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension
+# number (# 102) to specify these quantities and the NEI emissions.
+# This will make sure everything will be passed to the HEMCO PARANOX extension
 # rather than sending them into the base emissions.
 #------------------------------------------------------------------------------
 102  ICOADS_SHIP_NO    $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                NO     2002/1-12/1/0          C xy kg/m2/s  NO   1/5      10 1
@@ -1902,19 +1902,19 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 (((AEIC
 0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1 
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
 0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1  
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
 0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
 0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
 0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1 
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
 0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
 0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
 )))AEIC
@@ -1957,7 +1957,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_HCOOH   $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_total_acids_2005-2100_23474.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_CH4     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CH4_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP45_NOx     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NOx_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP45_CO      $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -1984,7 +1984,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_HCOOH   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_total_acids_2005-2100_27424.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_CH4     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CH4_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP60_NOx     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NOx_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP60_CO      $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2011,7 +2011,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_HCOOH   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_total_acids_2005-2100_43190.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_CH4     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CH4_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP85_NOx     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_NOx_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP85_CO      $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2042,44 +2042,44 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2 
-0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2 
-0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2 
-0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2 
-0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2 
-0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2 
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2
+0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2
+0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2
+0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2
+0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2
+0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2 
-0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2 
-0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2 
-0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2 
-0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2 
-0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2 
-0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2 
-0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2 
-0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
+0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
+0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
+0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2
+0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2
+0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2
+0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2
+0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2
+0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2
 0 QFED_SOAP_PBL  -                                                                 -       -                     - -             -       SOAP 54/75/281/311 5 2
-0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2 
+0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2
 0 QFED_SOAP_FT   -                                                                 -       -                     - -             -       SOAP 54/75/281/312 5 2
-0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2 
-0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2 
-0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2 
-0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2 
-0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
-0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2 
-0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2 
+0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2
+0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2
+0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2
+0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2
+0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
+0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -2188,11 +2188,11 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
@@ -2200,7 +2200,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 #101 CH3I_SEAWATER  $ROOT/CH3I/v2014-07/ocean_ch3i.geos.4x5.nc       CH3I_OCEAN 1985/1-12/1/0 C xy kg/m3 CH3I - 1 1
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 101 ALD2_SEAWATER   $ROOT/ALD2/v2017-03/ALD2_seawater.geos.2x25.nc   ALD2       1985/1-12/1/0 C xy kg/m3 ALD2 - 1 1
 
 #==============================================================================
@@ -2254,24 +2254,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -2312,7 +2312,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -2337,7 +2337,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -2363,17 +2363,17 @@ Warnings:                    {WARNINGS}
 )))FINN_daily
 
 #==============================================================================
-# --- Inorganic iodine emissions (Extension 115) 
+# --- Inorganic iodine emissions (Extension 115)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -2520,7 +2520,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -2848,7 +2848,7 @@ Warnings:                    {WARNINGS}
 * UCX_LOSS_AERI     $ROOT/UCX/v2018-02/UCX_ProdLoss.v11-02d.4x5.72L.nc PORL_L_S__LAERI     2013/1-12/1/0 C xyz molec/cm3/s AERI     - 1  1
 
 # Archived OH concentrations. These are always needed, so set species to wildcard (*) to make
-# sure that this entry will always be read. 
+# sure that this entry will always be read.
 * STRAT_OH            $ROOT/GMI/v2015-02/gmi.clim.OH.geos5.2x25.nc             species 2000/1-12/1/0 C xyz v/v   *        - 1  1
 )))+LinStratChem+
 
@@ -2863,7 +2863,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -3129,20 +3129,20 @@ Warnings:                    {WARNINGS}
 # --- Inputs for the RRTMG radiative transfer model ---
 #
 # These fields will only be read if the +RRTMG+ toggle is activated.
-# +RRTMG+ can be set explicitly above as a setting of the base extension 
-# (--> +RRTMG+: true/false). If not defined, it will be set automatically 
+# +RRTMG+ can be set explicitly above as a setting of the base extension
+# (--> +RRTMG+: true/false). If not defined, it will be set automatically
 # based on the RRTMG toggle in input.geos (recommended).
 #
-# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce 
+# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce
 # differences at the level of numerical noise when comparing output to
 # simulations from prior versions (esp. when running at 4 x 5 resolution).
 # You might see larger differences w/r/t prior verisons for a few grid boxes
 # along the coastline of Antarctica, where the difference in resolution
-# and regridding will be more apparent in the sharp transition from ice to 
+# and regridding will be more apparent in the sharp transition from ice to
 # ocean.  If this is a problem, you can use the data files at 4x5 resolution
 # for 4x5 RRTMG simulations.
 #
-# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is 
+# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is
 # likely different than what was implemented when reading the old bpch
 # data from disk.  This can also cause differences when comparing to
 # prior versions.
@@ -3179,7 +3179,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -3216,16 +3216,16 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
 # --- day-of-week scale factors ---
-# ==> data is Sun/Mon/.../Sat 
+# ==> data is Sun/Mon/.../Sat
 #==============================================================================
-22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1 
+22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1
 
 #==============================================================================
 # --- seasonal scale factors ---
@@ -3238,9 +3238,9 @@ Warnings:                    {WARNINGS}
 39 BROMOCARB_SEASON $ROOT/BROMINE/v2015-02/BromoCarb_Season.nc CHXBRY_scale 2000/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -3325,22 +3325,22 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- BIOGENIC EMISSIONS FROM DRY LEAF MATTER ---
@@ -3359,17 +3359,17 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 101 AEICACET 3.693477e-3 - -  - xy unitless 1
@@ -3408,13 +3408,13 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1 
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 260 NEI11_PAR2ACET    0.06                                          - -               - xy 1 1
 261 NEI11_PAR2C3H8    0.03                                          - -               - xy 1 1
 262 NEI11_PAR2MEK     0.02                                          - -               - xy 1 1
@@ -3428,7 +3428,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -3452,7 +3452,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -3482,7 +3482,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.TOMAS
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.TOMAS
@@ -1007,14 +1007,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
-0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
-0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
-0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
-0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
-0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
-0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
-0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
-0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
+0 AF_EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0 AF_EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/1008/71         1 2
+0 AF_EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0 AF_EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/1008/71         1 2
+0 AF_EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0 AF_EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/1008/71         1 2
+0 AF_EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0 AF_EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.UCX
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.UCX
@@ -6,16 +6,16 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
 # !REMARKS:
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -24,8 +24,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -55,11 +55,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -70,17 +70,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -89,7 +89,7 @@ Warnings:                    {WARNINGS}
 # ExtNr ExtName                on/off  Species
 0       Base                   : on    *
 # ----- RESTART FIELDS ----------------------
-    --> GC_RESTART             :       true	
+    --> GC_RESTART             :       true
     --> HEMCO_RESTART          :       true
 # ----- REGIONAL INVENTORIES ----------------
     --> APEI                   :       true
@@ -98,7 +98,7 @@ Warnings:                    {WARNINGS}
     --> NEI2011_SHIP_HOURLY    :       false
     --> NEI2011_SHIP_MONMEAN   :       false
     --> MIX                    :       true
-    --> DICE_Africa            :       true 
+    --> DICE_Africa            :       true
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -115,7 +115,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -131,19 +131,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2
 102     ParaNOx                : on    NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
-104     SoilNOx                : off   NO 
+104     SoilNOx                : off   NO
     --> Use fertilizer NOx     :       true
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC/Br2/BrSALA/BrSALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
@@ -152,7 +152,7 @@ Warnings:                    {WARNINGS}
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -183,7 +183,7 @@ Warnings:                    {WARNINGS}
     --> hydrophilic BC         :       0.2
     --> hydrophilic OC         :       0.5
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : off   MOPO/MOPI 
+116     MarinePOA              : off   MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
@@ -193,7 +193,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -699,27 +699,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  CO    26/1008         1 60
 0 DICE_CARS_SOAP  -                                                                 -       -          - -  -        SOAP  26/1008/280     1 60
@@ -745,7 +745,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_MOTORCYCLES_SOAP  -                                                                        -      -          - -  -        SOAP  26/1008/280      1 60
@@ -766,7 +766,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_BACKUPGEN_SOAP  -                                                                          -    -          - -  -        SOAP  26/1008/280      1 60
@@ -794,7 +794,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008/320      1 60
 0 DICE_CHARCOALPROD_SOAP  -                                                                                -     -          - -  -        SOAP  26/1008/280/320  1 60
@@ -815,7 +815,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_GASFLARE_SOAP  -                                                                       -     -          - -  -        SOAP  26/1008/280      1 60
@@ -833,7 +833,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_AGBURNING_SOAP  -                                                                                       -     -          - -  -        SOAP  26/1008/280      2 60
@@ -871,7 +871,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_CHARCOALUSE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      2 60
@@ -891,7 +891,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_KEROSENE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      1 60
@@ -901,7 +901,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_OILREFINING_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      1 60
@@ -926,7 +926,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_HOUSEFUELWOOD_SOAP  -                                                                                   -     -          - -  -        SOAP  26/1008/280      2 60
@@ -961,7 +961,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_OTHERFUELWOOD_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      2 60
@@ -1314,10 +1314,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -1454,7 +1454,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -1677,10 +1677,10 @@ Warnings:                    {WARNINGS}
 # NOTES:
 # - These C2H6 emissions are used in place of CEDS
 #==============================================================================
-(((C2H6_2010 
+(((C2H6_2010
 0 C2H6_2010_oilgas   $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc ANTHR_C2H6   2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
 0 C2H6_2010_biofuel  $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc BIOFUEL_C2H6 2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
-)))C2H6_2010 
+)))C2H6_2010
 
 #==============================================================================
 # --- Xiao et al., JGR, 2008 ---
@@ -1836,9 +1836,9 @@ Warnings:                    {WARNINGS}
 #------------------------------------------------------------------------------
 # ### IF THE PARANOX EXTENSION IS TURNED ON ###
 #
-# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension 
-# number (# 102) to specify these quantities and the NEI emissions.  
-# This will make sure everything will be passed to the HEMCO PARANOX extension 
+# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension
+# number (# 102) to specify these quantities and the NEI emissions.
+# This will make sure everything will be passed to the HEMCO PARANOX extension
 # rather than sending them into the base emissions.
 #------------------------------------------------------------------------------
 102  ICOADS_SHIP_NO    $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                NO     2002/1-12/1/0          C xy kg/m2/s  NO   1/5      10 1
@@ -1896,19 +1896,19 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 (((AEIC
 0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1 
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
 0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1  
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
 0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
 0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
 0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1 
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
 0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
 0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
 )))AEIC
@@ -1951,7 +1951,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_HCOOH   $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_total_acids_2005-2100_23474.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_CH4     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CH4_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP45_NOx     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NOx_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP45_CO      $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -1978,7 +1978,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_HCOOH   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_total_acids_2005-2100_27424.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_CH4     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CH4_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP60_NOx     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NOx_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP60_CO      $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2005,7 +2005,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_HCOOH   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_total_acids_2005-2100_43190.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_CH4     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CH4_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP85_NOx     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_NOx_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP85_CO      $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2036,44 +2036,44 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2 
-0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2 
-0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2 
-0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2 
-0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2 
-0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2 
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2
+0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2
+0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2
+0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2
+0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2
+0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2 
-0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2 
-0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2 
-0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2 
-0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2 
-0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2 
-0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2 
-0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2 
-0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
+0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
+0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
+0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2
+0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2
+0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2
+0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2
+0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2
+0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2
 0 QFED_SOAP_PBL  -                                                                 -       -                     - -             -       SOAP 54/75/281/311 5 2
-0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2 
+0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2
 0 QFED_SOAP_FT   -                                                                 -       -                     - -             -       SOAP 54/75/281/312 5 2
-0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2 
-0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2 
-0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2 
-0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2 
-0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
-0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2 
-0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2 
+0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2
+0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2
+0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2
+0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2
+0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
+0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -2182,11 +2182,11 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
@@ -2194,7 +2194,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 #101 CH3I_SEAWATER  $ROOT/CH3I/v2014-07/ocean_ch3i.geos.4x5.nc       CH3I_OCEAN 1985/1-12/1/0 C xy kg/m3 CH3I - 1 1
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 101 ALD2_SEAWATER   $ROOT/ALD2/v2017-03/ALD2_seawater.geos.2x25.nc   ALD2       1985/1-12/1/0 C xy kg/m3 ALD2 - 1 1
 
 #==============================================================================
@@ -2248,24 +2248,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -2306,7 +2306,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -2327,7 +2327,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -2348,17 +2348,17 @@ Warnings:                    {WARNINGS}
 )))FINN_daily
 
 #==============================================================================
-# --- Inorganic iodine emissions (Extension 115) 
+# --- Inorganic iodine emissions (Extension 115)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -2505,7 +2505,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -2787,7 +2787,7 @@ Warnings:                    {WARNINGS}
 * GMI_PROD_VRP        $ROOT/GMI/v2015-02/gmi.clim.VRP.geos5.2x25.nc            prod    2000/1-12/1/0 C xyz v/v/s VRP      - 1  1
 
 # Archived OH concentrations. These are always needed, so set species to wildcard (*) to make
-# sure that this entry will always be read. 
+# sure that this entry will always be read.
 * STRAT_OH            $ROOT/GMI/v2015-02/gmi.clim.OH.geos5.2x25.nc             species 2000/1-12/1/0 C xyz v/v   *        - 1  1
 )))+LinStratChem+
 
@@ -2802,7 +2802,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -3067,7 +3067,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -3104,16 +3104,16 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
 # --- day-of-week scale factors ---
-# ==> data is Sun/Mon/.../Sat 
+# ==> data is Sun/Mon/.../Sat
 #==============================================================================
-22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1 
+22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1
 
 #==============================================================================
 # --- seasonal scale factors ---
@@ -3126,9 +3126,9 @@ Warnings:                    {WARNINGS}
 39 BROMOCARB_SEASON $ROOT/BROMINE/v2015-02/BromoCarb_Season.nc CHXBRY_scale 2000/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -3213,22 +3213,22 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- BIOGENIC EMISSIONS FROM DRY LEAF MATTER ---
@@ -3247,17 +3247,17 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 101 AEICACET 3.693477e-3 - -  - xy unitless 1
@@ -3296,13 +3296,13 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1 
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 260 NEI11_PAR2ACET    0.06                                          - -               - xy 1 1
 261 NEI11_PAR2C3H8    0.03                                          - -               - xy 1 1
 262 NEI11_PAR2MEK     0.02                                          - -               - xy 1 1
@@ -3316,7 +3316,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -3340,7 +3340,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -3370,7 +3370,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.UCX
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.UCX
@@ -1001,6 +1001,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
+0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.aciduptake
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.aciduptake
@@ -6,16 +6,16 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
 # !REMARKS:
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -24,8 +24,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -55,11 +55,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -70,17 +70,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -89,7 +89,7 @@ Warnings:                    {WARNINGS}
 # ExtNr ExtName                on/off  Species
 0       Base                   : on    *
 # ----- RESTART FIELDS ----------------------
-    --> GC_RESTART             :       true	
+    --> GC_RESTART             :       true
     --> HEMCO_RESTART          :       true
 # ----- REGIONAL INVENTORIES ----------------
     --> APEI                   :       true
@@ -98,7 +98,7 @@ Warnings:                    {WARNINGS}
     --> NEI2011_SHIP_HOURLY    :       false
     --> NEI2011_SHIP_MONMEAN   :       false
     --> MIX                    :       true
-    --> DICE_Africa            :       true 
+    --> DICE_Africa            :       true
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -115,7 +115,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -131,19 +131,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2
 102     ParaNOx                : on    NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
-104     SoilNOx                : off   NO 
+104     SoilNOx                : off   NO
     --> Use fertilizer NOx     :       true
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC/Br2/BrSALA/BrSALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
@@ -152,7 +152,7 @@ Warnings:                    {WARNINGS}
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -183,7 +183,7 @@ Warnings:                    {WARNINGS}
     --> hydrophilic BC         :       0.2
     --> hydrophilic OC         :       0.5
 115     DustAlk                : on    DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : off   MOPO/MOPI 
+116     MarinePOA              : off   MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
@@ -193,7 +193,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -699,27 +699,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  CO    26/1008         1 60
 0 DICE_CARS_SOAP  -                                                                 -       -          - -  -        SOAP  26/1008/280     1 60
@@ -745,7 +745,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_MOTORCYCLES_SOAP  -                                                                        -      -          - -  -        SOAP  26/1008/280      1 60
@@ -766,7 +766,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_BACKUPGEN_SOAP  -                                                                          -    -          - -  -        SOAP  26/1008/280      1 60
@@ -794,7 +794,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008/320      1 60
 0 DICE_CHARCOALPROD_SOAP  -                                                                                -     -          - -  -        SOAP  26/1008/280/320  1 60
@@ -815,7 +815,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_GASFLARE_SOAP  -                                                                       -     -          - -  -        SOAP  26/1008/280      1 60
@@ -833,7 +833,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_AGBURNING_SOAP  -                                                                                       -     -          - -  -        SOAP  26/1008/280      2 60
@@ -871,7 +871,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_CHARCOALUSE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      2 60
@@ -891,7 +891,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_KEROSENE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      1 60
@@ -901,7 +901,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_OILREFINING_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      1 60
@@ -926,7 +926,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_HOUSEFUELWOOD_SOAP  -                                                                                   -     -          - -  -        SOAP  26/1008/280      2 60
@@ -961,7 +961,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_OTHERFUELWOOD_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      2 60
@@ -1314,10 +1314,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -1454,7 +1454,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -1677,10 +1677,10 @@ Warnings:                    {WARNINGS}
 # NOTES:
 # - These C2H6 emissions are used in place of CEDS
 #==============================================================================
-(((C2H6_2010 
+(((C2H6_2010
 0 C2H6_2010_oilgas   $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc ANTHR_C2H6   2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
 0 C2H6_2010_biofuel  $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc BIOFUEL_C2H6 2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
-)))C2H6_2010 
+)))C2H6_2010
 
 #==============================================================================
 # --- Xiao et al., JGR, 2008 ---
@@ -1836,9 +1836,9 @@ Warnings:                    {WARNINGS}
 #------------------------------------------------------------------------------
 # ### IF THE PARANOX EXTENSION IS TURNED ON ###
 #
-# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension 
-# number (# 102) to specify these quantities and the NEI emissions.  
-# This will make sure everything will be passed to the HEMCO PARANOX extension 
+# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension
+# number (# 102) to specify these quantities and the NEI emissions.
+# This will make sure everything will be passed to the HEMCO PARANOX extension
 # rather than sending them into the base emissions.
 #------------------------------------------------------------------------------
 102  ICOADS_SHIP_NO    $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                NO     2002/1-12/1/0          C xy kg/m2/s  NO   1/5      10 1
@@ -1896,19 +1896,19 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 (((AEIC
 0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1 
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
 0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1  
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
 0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
 0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
 0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1 
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
 0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
 0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
 )))AEIC
@@ -1951,7 +1951,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_HCOOH   $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_total_acids_2005-2100_23474.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_CH4     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CH4_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP45_NOx     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NOx_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP45_CO      $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -1978,7 +1978,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_HCOOH   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_total_acids_2005-2100_27424.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_CH4     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CH4_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP60_NOx     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NOx_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP60_CO      $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2005,7 +2005,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_HCOOH   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_total_acids_2005-2100_43190.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_CH4     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CH4_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP85_NOx     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_NOx_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP85_CO      $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2036,44 +2036,44 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2 
-0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2 
-0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2 
-0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2 
-0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2 
-0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2 
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2
+0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2
+0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2
+0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2
+0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2
+0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2 
-0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2 
-0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2 
-0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2 
-0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2 
-0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2 
-0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2 
-0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2 
-0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
+0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
+0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
+0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2
+0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2
+0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2
+0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2
+0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2
+0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2
 0 QFED_SOAP_PBL  -                                                                 -       -                     - -             -       SOAP 54/75/281/311 5 2
-0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2 
+0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2
 0 QFED_SOAP_FT   -                                                                 -       -                     - -             -       SOAP 54/75/281/312 5 2
-0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2 
-0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2 
-0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2 
-0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2 
-0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
-0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2 
-0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2 
+0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2
+0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2
+0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2
+0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2
+0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
+0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -2182,11 +2182,11 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
@@ -2194,7 +2194,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 #101 CH3I_SEAWATER  $ROOT/CH3I/v2014-07/ocean_ch3i.geos.4x5.nc       CH3I_OCEAN 1985/1-12/1/0 C xy kg/m3 CH3I - 1 1
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 101 ALD2_SEAWATER   $ROOT/ALD2/v2017-03/ALD2_seawater.geos.2x25.nc   ALD2       1985/1-12/1/0 C xy kg/m3 ALD2 - 1 1
 
 #==============================================================================
@@ -2248,24 +2248,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -2306,7 +2306,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -2327,7 +2327,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -2348,17 +2348,17 @@ Warnings:                    {WARNINGS}
 )))FINN_daily
 
 #==============================================================================
-# --- Inorganic iodine emissions (Extension 115) 
+# --- Inorganic iodine emissions (Extension 115)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -2505,7 +2505,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -2787,7 +2787,7 @@ Warnings:                    {WARNINGS}
 * GMI_PROD_VRP        $ROOT/GMI/v2015-02/gmi.clim.VRP.geos5.2x25.nc            prod    2000/1-12/1/0 C xyz v/v/s VRP      - 1  1
 
 # Archived OH concentrations. These are always needed, so set species to wildcard (*) to make
-# sure that this entry will always be read. 
+# sure that this entry will always be read.
 * STRAT_OH            $ROOT/GMI/v2015-02/gmi.clim.OH.geos5.2x25.nc             species 2000/1-12/1/0 C xyz v/v   *        - 1  1
 )))+LinStratChem+
 
@@ -2802,7 +2802,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -3067,7 +3067,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -3104,16 +3104,16 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
 # --- day-of-week scale factors ---
-# ==> data is Sun/Mon/.../Sat 
+# ==> data is Sun/Mon/.../Sat
 #==============================================================================
-22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1 
+22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1
 
 #==============================================================================
 # --- seasonal scale factors ---
@@ -3126,9 +3126,9 @@ Warnings:                    {WARNINGS}
 39 BROMOCARB_SEASON $ROOT/BROMINE/v2015-02/BromoCarb_Season.nc CHXBRY_scale 2000/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -3213,22 +3213,22 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- BIOGENIC EMISSIONS FROM DRY LEAF MATTER ---
@@ -3247,17 +3247,17 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 101 AEICACET 3.693477e-3 - -  - xy unitless 1
@@ -3296,13 +3296,13 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1 
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 260 NEI11_PAR2ACET    0.06                                          - -               - xy 1 1
 261 NEI11_PAR2C3H8    0.03                                          - -               - xy 1 1
 262 NEI11_PAR2MEK     0.02                                          - -               - xy 1 1
@@ -3316,7 +3316,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -3340,7 +3340,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -3370,7 +3370,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.aciduptake
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.aciduptake
@@ -1001,6 +1001,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
+0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.aciduptake
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.aciduptake
@@ -1001,14 +1001,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
-0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
-0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
-0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
-0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
-0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
-0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
-0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
-0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
+0 AF_EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0 AF_EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0 AF_EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0 AF_EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0 AF_EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0 AF_EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0 AF_EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0 AF_EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.asia
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.asia
@@ -6,9 +6,9 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
@@ -18,7 +18,7 @@
 #
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -27,8 +27,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -58,11 +58,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -73,17 +73,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -92,7 +92,7 @@ Warnings:                    {WARNINGS}
 # ExtNr ExtName                on/off  Species
 0       Base                   : on    *
 # ----- RESTART FIELDS ----------------------
-    --> GC_RESTART             :       true	
+    --> GC_RESTART             :       true
     --> GC_BCs                 :       true
     --> HEMCO_RESTART          :       true
 # ----- REGIONAL INVENTORIES ----------------
@@ -119,7 +119,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -135,19 +135,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2
 102     ParaNOx                : on    NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
-104     SoilNOx                : off   NO 
+104     SoilNOx                : off   NO
     --> Use fertilizer NOx     :       true
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC/Br2/BrSALA/BrSALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
@@ -156,7 +156,7 @@ Warnings:                    {WARNINGS}
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -187,7 +187,7 @@ Warnings:                    {WARNINGS}
     --> hydrophilic BC         :       0.2
     --> hydrophilic OC         :       0.5
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : off   MOPO/MOPI 
+116     MarinePOA              : off   MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
@@ -197,7 +197,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -703,27 +703,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  CO    26/1008         1 60
 0 DICE_CARS_SOAP  -                                                                 -       -          - -  -        SOAP  26/1008/280     1 60
@@ -749,7 +749,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_MOTORCYCLES_SOAP  -                                                                        -      -          - -  -        SOAP  26/1008/280      1 60
@@ -770,7 +770,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_BACKUPGEN_SOAP  -                                                                          -    -          - -  -        SOAP  26/1008/280      1 60
@@ -798,7 +798,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008/320      1 60
 0 DICE_CHARCOALPROD_SOAP  -                                                                                -     -          - -  -        SOAP  26/1008/280/320  1 60
@@ -819,7 +819,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_GASFLARE_SOAP  -                                                                       -     -          - -  -        SOAP  26/1008/280      1 60
@@ -837,7 +837,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_AGBURNING_SOAP  -                                                                                       -     -          - -  -        SOAP  26/1008/280      2 60
@@ -875,7 +875,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_CHARCOALUSE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      2 60
@@ -895,7 +895,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_KEROSENE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      1 60
@@ -905,7 +905,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_OILREFINING_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      1 60
@@ -930,7 +930,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_HOUSEFUELWOOD_SOAP  -                                                                                   -     -          - -  -        SOAP  26/1008/280      2 60
@@ -965,7 +965,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_OTHERFUELWOOD_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      2 60
@@ -1318,10 +1318,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -1458,7 +1458,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -1681,10 +1681,10 @@ Warnings:                    {WARNINGS}
 # NOTES:
 # - These C2H6 emissions are used in place of CEDS
 #==============================================================================
-(((C2H6_2010 
+(((C2H6_2010
 0 C2H6_2010_oilgas   $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc ANTHR_C2H6   2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
 0 C2H6_2010_biofuel  $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc BIOFUEL_C2H6 2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
-)))C2H6_2010 
+)))C2H6_2010
 
 #==============================================================================
 # --- Xiao et al., JGR, 2008 ---
@@ -1840,9 +1840,9 @@ Warnings:                    {WARNINGS}
 #------------------------------------------------------------------------------
 # ### IF THE PARANOX EXTENSION IS TURNED ON ###
 #
-# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension 
-# number (# 102) to specify these quantities and the NEI emissions.  
-# This will make sure everything will be passed to the HEMCO PARANOX extension 
+# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension
+# number (# 102) to specify these quantities and the NEI emissions.
+# This will make sure everything will be passed to the HEMCO PARANOX extension
 # rather than sending them into the base emissions.
 #------------------------------------------------------------------------------
 102  ICOADS_SHIP_NO    $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                NO     2002/1-12/1/0          C xy kg/m2/s  NO   1/5      10 1
@@ -1900,19 +1900,19 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 (((AEIC
 0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1 
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
 0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1  
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
 0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
 0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
 0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1 
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
 0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
 0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
 )))AEIC
@@ -1955,7 +1955,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_HCOOH   $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_total_acids_2005-2100_23474.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_CH4     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CH4_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP45_NOx     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NOx_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP45_CO      $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -1982,7 +1982,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_HCOOH   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_total_acids_2005-2100_27424.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_CH4     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CH4_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP60_NOx     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NOx_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP60_CO      $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2009,7 +2009,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_HCOOH   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_total_acids_2005-2100_43190.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_CH4     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CH4_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP85_NOx     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_NOx_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP85_CO      $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2040,44 +2040,44 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2 
-0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2 
-0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2 
-0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2 
-0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2 
-0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2 
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2
+0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2
+0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2
+0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2
+0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2
+0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2 
-0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2 
-0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2 
-0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2 
-0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2 
-0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2 
-0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2 
-0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2 
-0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
+0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
+0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
+0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2
+0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2
+0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2
+0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2
+0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2
+0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2
 0 QFED_SOAP_PBL  -                                                                 -       -                     - -             -       SOAP 54/75/281/311 5 2
-0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2 
+0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2
 0 QFED_SOAP_FT   -                                                                 -       -                     - -             -       SOAP 54/75/281/312 5 2
-0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2 
-0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2 
-0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2 
-0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2 
-0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
-0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2 
-0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2 
+0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2
+0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2
+0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2
+0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2
+0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
+0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -2186,11 +2186,11 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
@@ -2198,7 +2198,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 #101 CH3I_SEAWATER  $ROOT/CH3I/v2014-07/ocean_ch3i.geos.4x5.nc       CH3I_OCEAN 1985/1-12/1/0 C xy kg/m3 CH3I - 1 1
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 101 ALD2_SEAWATER   $ROOT/ALD2/v2017-03/ALD2_seawater.geos.2x25.nc   ALD2       1985/1-12/1/0 C xy kg/m3 ALD2 - 1 1
 
 #==============================================================================
@@ -2252,24 +2252,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -2310,7 +2310,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -2331,7 +2331,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -2352,17 +2352,17 @@ Warnings:                    {WARNINGS}
 )))FINN_daily
 
 #==============================================================================
-# --- Inorganic iodine emissions (Extension 115) 
+# --- Inorganic iodine emissions (Extension 115)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -2516,7 +2516,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -2844,7 +2844,7 @@ Warnings:                    {WARNINGS}
 * UCX_LOSS_AERI     $ROOT/UCX/v2018-02/UCX_ProdLoss.v11-02d.4x5.72L.nc PORL_L_S__LAERI     2013/1-12/1/0 C xyz molec/cm3/s AERI     - 1  1
 
 # Archived OH concentrations. These are always needed, so set species to wildcard (*) to make
-# sure that this entry will always be read. 
+# sure that this entry will always be read.
 * STRAT_OH            $ROOT/GMI/v2015-02/gmi.clim.OH.geos5.2x25.nc             species 2000/1-12/1/0 C xyz v/v   *        - 1  1
 )))+LinStratChem+
 
@@ -2859,7 +2859,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -3125,20 +3125,20 @@ Warnings:                    {WARNINGS}
 # --- Inputs for the RRTMG radiative transfer model ---
 #
 # These fields will only be read if the +RRTMG+ toggle is activated.
-# +RRTMG+ can be set explicitly above as a setting of the base extension 
-# (--> +RRTMG+: true/false). If not defined, it will be set automatically 
+# +RRTMG+ can be set explicitly above as a setting of the base extension
+# (--> +RRTMG+: true/false). If not defined, it will be set automatically
 # based on the RRTMG toggle in input.geos (recommended).
 #
-# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce 
+# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce
 # differences at the level of numerical noise when comparing output to
 # simulations from prior versions (esp. when running at 4 x 5 resolution).
 # You might see larger differences w/r/t prior verisons for a few grid boxes
 # along the coastline of Antarctica, where the difference in resolution
-# and regridding will be more apparent in the sharp transition from ice to 
+# and regridding will be more apparent in the sharp transition from ice to
 # ocean.  If this is a problem, you can use the data files at 4x5 resolution
 # for 4x5 RRTMG simulations.
 #
-# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is 
+# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is
 # likely different than what was implemented when reading the old bpch
 # data from disk.  This can also cause differences when comparing to
 # prior versions.
@@ -3175,7 +3175,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -3212,16 +3212,16 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
 # --- day-of-week scale factors ---
-# ==> data is Sun/Mon/.../Sat 
+# ==> data is Sun/Mon/.../Sat
 #==============================================================================
-22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1 
+22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1
 
 #==============================================================================
 # --- seasonal scale factors ---
@@ -3234,9 +3234,9 @@ Warnings:                    {WARNINGS}
 39 BROMOCARB_SEASON $ROOT/BROMINE/v2015-02/BromoCarb_Season.nc CHXBRY_scale 2000/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -3321,22 +3321,22 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- BIOGENIC EMISSIONS FROM DRY LEAF MATTER ---
@@ -3355,17 +3355,17 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 101 AEICACET 3.693477e-3 - -  - xy unitless 1
@@ -3404,13 +3404,13 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1 
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 260 NEI11_PAR2ACET    0.06                                          - -               - xy 1 1
 261 NEI11_PAR2C3H8    0.03                                          - -               - xy 1 1
 262 NEI11_PAR2MEK     0.02                                          - -               - xy 1 1
@@ -3424,7 +3424,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -3448,7 +3448,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -3478,7 +3478,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.asia
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.asia
@@ -1005,6 +1005,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
+0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.asia
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.asia
@@ -1005,14 +1005,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
-0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
-0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
-0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
-0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
-0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
-0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
-0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
-0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
+0 AF_EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0 AF_EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0 AF_EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0 AF_EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0 AF_EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0 AF_EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0 AF_EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0 AF_EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.marinePOA
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.marinePOA
@@ -1001,6 +1001,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
+0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.marinePOA
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.marinePOA
@@ -6,16 +6,16 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
 # !REMARKS:
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -24,8 +24,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -55,11 +55,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -70,17 +70,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -89,7 +89,7 @@ Warnings:                    {WARNINGS}
 # ExtNr ExtName                on/off  Species
 0       Base                   : on    *
 # ----- RESTART FIELDS ----------------------
-    --> GC_RESTART             :       true	
+    --> GC_RESTART             :       true
     --> HEMCO_RESTART          :       true
 # ----- REGIONAL INVENTORIES ----------------
     --> APEI                   :       true
@@ -98,7 +98,7 @@ Warnings:                    {WARNINGS}
     --> NEI2011_SHIP_HOURLY    :       false
     --> NEI2011_SHIP_MONMEAN   :       false
     --> MIX                    :       true
-    --> DICE_Africa            :       true 
+    --> DICE_Africa            :       true
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -115,7 +115,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -131,19 +131,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2
 102     ParaNOx                : on    NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
-104     SoilNOx                : off   NO 
+104     SoilNOx                : off   NO
     --> Use fertilizer NOx     :       true
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC/Br2/BrSALA/BrSALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
@@ -152,7 +152,7 @@ Warnings:                    {WARNINGS}
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -183,7 +183,7 @@ Warnings:                    {WARNINGS}
     --> hydrophilic BC         :       0.2
     --> hydrophilic OC         :       0.5
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : on    MOPO/MOPI 
+116     MarinePOA              : on    MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
@@ -193,7 +193,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -699,27 +699,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  CO    26/1008         1 60
 0 DICE_CARS_SOAP  -                                                                 -       -          - -  -        SOAP  26/1008/280     1 60
@@ -745,7 +745,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_MOTORCYCLES_SOAP  -                                                                        -      -          - -  -        SOAP  26/1008/280      1 60
@@ -766,7 +766,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_BACKUPGEN_SOAP  -                                                                          -    -          - -  -        SOAP  26/1008/280      1 60
@@ -794,7 +794,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008/320      1 60
 0 DICE_CHARCOALPROD_SOAP  -                                                                                -     -          - -  -        SOAP  26/1008/280/320  1 60
@@ -815,7 +815,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_GASFLARE_SOAP  -                                                                       -     -          - -  -        SOAP  26/1008/280      1 60
@@ -833,7 +833,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_AGBURNING_SOAP  -                                                                                       -     -          - -  -        SOAP  26/1008/280      2 60
@@ -871,7 +871,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_CHARCOALUSE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      2 60
@@ -891,7 +891,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_KEROSENE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      1 60
@@ -901,7 +901,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_OILREFINING_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      1 60
@@ -926,7 +926,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_HOUSEFUELWOOD_SOAP  -                                                                                   -     -          - -  -        SOAP  26/1008/280      2 60
@@ -961,7 +961,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_OTHERFUELWOOD_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      2 60
@@ -1314,10 +1314,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -1454,7 +1454,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -1677,10 +1677,10 @@ Warnings:                    {WARNINGS}
 # NOTES:
 # - These C2H6 emissions are used in place of CEDS
 #==============================================================================
-(((C2H6_2010 
+(((C2H6_2010
 0 C2H6_2010_oilgas   $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc ANTHR_C2H6   2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
 0 C2H6_2010_biofuel  $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc BIOFUEL_C2H6 2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
-)))C2H6_2010 
+)))C2H6_2010
 
 #==============================================================================
 # --- Xiao et al., JGR, 2008 ---
@@ -1836,9 +1836,9 @@ Warnings:                    {WARNINGS}
 #------------------------------------------------------------------------------
 # ### IF THE PARANOX EXTENSION IS TURNED ON ###
 #
-# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension 
-# number (# 102) to specify these quantities and the NEI emissions.  
-# This will make sure everything will be passed to the HEMCO PARANOX extension 
+# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension
+# number (# 102) to specify these quantities and the NEI emissions.
+# This will make sure everything will be passed to the HEMCO PARANOX extension
 # rather than sending them into the base emissions.
 #------------------------------------------------------------------------------
 102  ICOADS_SHIP_NO    $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                NO     2002/1-12/1/0          C xy kg/m2/s  NO   1/5      10 1
@@ -1896,19 +1896,19 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 (((AEIC
 0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1 
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
 0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1  
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
 0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
 0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
 0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1 
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
 0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
 0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
 )))AEIC
@@ -1951,7 +1951,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_HCOOH   $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_total_acids_2005-2100_23474.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_CH4     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CH4_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP45_NOx     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NOx_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP45_CO      $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -1978,7 +1978,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_HCOOH   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_total_acids_2005-2100_27424.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_CH4     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CH4_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP60_NOx     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NOx_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP60_CO      $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2005,7 +2005,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_HCOOH   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_total_acids_2005-2100_43190.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_CH4     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CH4_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP85_NOx     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_NOx_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP85_CO      $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2036,44 +2036,44 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2 
-0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2 
-0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2 
-0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2 
-0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2 
-0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2 
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2
+0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2
+0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2
+0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2
+0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2
+0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2 
-0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2 
-0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2 
-0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2 
-0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2 
-0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2 
-0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2 
-0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2 
-0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
+0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
+0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
+0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2
+0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2
+0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2
+0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2
+0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2
+0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2
 0 QFED_SOAP_PBL  -                                                                 -       -                     - -             -       SOAP 54/75/281/311 5 2
-0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2 
+0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2
 0 QFED_SOAP_FT   -                                                                 -       -                     - -             -       SOAP 54/75/281/312 5 2
-0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2 
-0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2 
-0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2 
-0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2 
-0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
-0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2 
-0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2 
+0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2
+0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2
+0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2
+0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2
+0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
+0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -2182,11 +2182,11 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
@@ -2194,7 +2194,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 #101 CH3I_SEAWATER  $ROOT/CH3I/v2014-07/ocean_ch3i.geos.4x5.nc       CH3I_OCEAN 1985/1-12/1/0 C xy kg/m3 CH3I - 1 1
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 101 ALD2_SEAWATER   $ROOT/ALD2/v2017-03/ALD2_seawater.geos.2x25.nc   ALD2       1985/1-12/1/0 C xy kg/m3 ALD2 - 1 1
 
 #==============================================================================
@@ -2248,24 +2248,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -2306,7 +2306,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -2327,7 +2327,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -2348,17 +2348,17 @@ Warnings:                    {WARNINGS}
 )))FINN_daily
 
 #==============================================================================
-# --- Inorganic iodine emissions (Extension 115) 
+# --- Inorganic iodine emissions (Extension 115)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -2505,7 +2505,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -2787,7 +2787,7 @@ Warnings:                    {WARNINGS}
 * GMI_PROD_VRP        $ROOT/GMI/v2015-02/gmi.clim.VRP.geos5.2x25.nc            prod    2000/1-12/1/0 C xyz v/v/s VRP      - 1  1
 
 # Archived OH concentrations. These are always needed, so set species to wildcard (*) to make
-# sure that this entry will always be read. 
+# sure that this entry will always be read.
 * STRAT_OH            $ROOT/GMI/v2015-02/gmi.clim.OH.geos5.2x25.nc             species 2000/1-12/1/0 C xyz v/v   *        - 1  1
 )))+LinStratChem+
 
@@ -2802,7 +2802,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -3067,7 +3067,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -3104,16 +3104,16 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
 # --- day-of-week scale factors ---
-# ==> data is Sun/Mon/.../Sat 
+# ==> data is Sun/Mon/.../Sat
 #==============================================================================
-22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1 
+22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1
 
 #==============================================================================
 # --- seasonal scale factors ---
@@ -3126,9 +3126,9 @@ Warnings:                    {WARNINGS}
 39 BROMOCARB_SEASON $ROOT/BROMINE/v2015-02/BromoCarb_Season.nc CHXBRY_scale 2000/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -3213,22 +3213,22 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- BIOGENIC EMISSIONS FROM DRY LEAF MATTER ---
@@ -3247,17 +3247,17 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 101 AEICACET 3.693477e-3 - -  - xy unitless 1
@@ -3296,13 +3296,13 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1 
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 260 NEI11_PAR2ACET    0.06                                          - -               - xy 1 1
 261 NEI11_PAR2C3H8    0.03                                          - -               - xy 1 1
 262 NEI11_PAR2MEK     0.02                                          - -               - xy 1 1
@@ -3316,7 +3316,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -3340,7 +3340,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -3370,7 +3370,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.marinePOA
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.marinePOA
@@ -1001,14 +1001,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
-0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
-0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
-0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
-0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
-0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
-0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
-0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
-0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
+0 AF_EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0 AF_EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/1008/71         1 2
+0 AF_EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0 AF_EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/1008/71         1 2
+0 AF_EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0 AF_EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/1008/71         1 2
+0 AF_EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0 AF_EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.na
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.na
@@ -1005,6 +1005,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
+0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.na
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.na
@@ -6,9 +6,9 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
@@ -18,7 +18,7 @@
 #
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -27,8 +27,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -58,11 +58,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -73,17 +73,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -92,7 +92,7 @@ Warnings:                    {WARNINGS}
 # ExtNr ExtName                on/off  Species
 0       Base                   : on    *
 # ----- RESTART FIELDS ----------------------
-    --> GC_RESTART             :       true	
+    --> GC_RESTART             :       true
     --> GC_BCs                 :       true
     --> HEMCO_RESTART          :       true
 # ----- REGIONAL INVENTORIES ----------------
@@ -102,7 +102,7 @@ Warnings:                    {WARNINGS}
     --> NEI2011_SHIP_HOURLY    :       false
     --> NEI2011_SHIP_MONMEAN   :       false
     --> MIX                    :       false
-    --> DICE_Africa            :       false 
+    --> DICE_Africa            :       false
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -119,7 +119,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -135,19 +135,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2
 102     ParaNOx                : on    NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
-104     SoilNOx                : off   NO 
+104     SoilNOx                : off   NO
     --> Use fertilizer NOx     :       true
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC/Br2/BrSALA/BrSALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
@@ -156,7 +156,7 @@ Warnings:                    {WARNINGS}
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -187,7 +187,7 @@ Warnings:                    {WARNINGS}
     --> hydrophilic BC         :       0.2
     --> hydrophilic OC         :       0.5
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : off   MOPO/MOPI 
+116     MarinePOA              : off   MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
@@ -197,7 +197,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -703,27 +703,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  CO    26/1008         1 60
 0 DICE_CARS_SOAP  -                                                                 -       -          - -  -        SOAP  26/1008/280     1 60
@@ -749,7 +749,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_MOTORCYCLES_SOAP  -                                                                        -      -          - -  -        SOAP  26/1008/280      1 60
@@ -770,7 +770,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_BACKUPGEN_SOAP  -                                                                          -    -          - -  -        SOAP  26/1008/280      1 60
@@ -798,7 +798,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008/320      1 60
 0 DICE_CHARCOALPROD_SOAP  -                                                                                -     -          - -  -        SOAP  26/1008/280/320  1 60
@@ -819,7 +819,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_GASFLARE_SOAP  -                                                                       -     -          - -  -        SOAP  26/1008/280      1 60
@@ -837,7 +837,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_AGBURNING_SOAP  -                                                                                       -     -          - -  -        SOAP  26/1008/280      2 60
@@ -875,7 +875,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_CHARCOALUSE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      2 60
@@ -895,7 +895,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_KEROSENE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      1 60
@@ -905,7 +905,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_OILREFINING_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      1 60
@@ -930,7 +930,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_HOUSEFUELWOOD_SOAP  -                                                                                   -     -          - -  -        SOAP  26/1008/280      2 60
@@ -965,7 +965,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_OTHERFUELWOOD_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      2 60
@@ -1318,10 +1318,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -1458,7 +1458,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -1681,10 +1681,10 @@ Warnings:                    {WARNINGS}
 # NOTES:
 # - These C2H6 emissions are used in place of CEDS
 #==============================================================================
-(((C2H6_2010 
+(((C2H6_2010
 0 C2H6_2010_oilgas   $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc ANTHR_C2H6   2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
 0 C2H6_2010_biofuel  $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc BIOFUEL_C2H6 2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
-)))C2H6_2010 
+)))C2H6_2010
 
 #==============================================================================
 # --- Xiao et al., JGR, 2008 ---
@@ -1840,9 +1840,9 @@ Warnings:                    {WARNINGS}
 #------------------------------------------------------------------------------
 # ### IF THE PARANOX EXTENSION IS TURNED ON ###
 #
-# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension 
-# number (# 102) to specify these quantities and the NEI emissions.  
-# This will make sure everything will be passed to the HEMCO PARANOX extension 
+# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension
+# number (# 102) to specify these quantities and the NEI emissions.
+# This will make sure everything will be passed to the HEMCO PARANOX extension
 # rather than sending them into the base emissions.
 #------------------------------------------------------------------------------
 102  ICOADS_SHIP_NO    $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                NO     2002/1-12/1/0          C xy kg/m2/s  NO   1/5      10 1
@@ -1900,19 +1900,19 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 (((AEIC
 0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1 
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
 0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1  
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
 0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
 0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
 0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1 
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
 0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
 0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
 )))AEIC
@@ -1955,7 +1955,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_HCOOH   $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_total_acids_2005-2100_23474.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_CH4     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CH4_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP45_NOx     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NOx_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP45_CO      $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -1982,7 +1982,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_HCOOH   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_total_acids_2005-2100_27424.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_CH4     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CH4_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP60_NOx     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NOx_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP60_CO      $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2009,7 +2009,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_HCOOH   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_total_acids_2005-2100_43190.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_CH4     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CH4_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP85_NOx     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_NOx_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP85_CO      $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2040,44 +2040,44 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2 
-0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2 
-0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2 
-0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2 
-0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2 
-0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2 
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2
+0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2
+0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2
+0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2
+0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2
+0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2 
-0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2 
-0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2 
-0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2 
-0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2 
-0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2 
-0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2 
-0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2 
-0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
+0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
+0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
+0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2
+0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2
+0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2
+0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2
+0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2
+0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2
 0 QFED_SOAP_PBL  -                                                                 -       -                     - -             -       SOAP 54/75/281/311 5 2
-0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2 
+0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2
 0 QFED_SOAP_FT   -                                                                 -       -                     - -             -       SOAP 54/75/281/312 5 2
-0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2 
-0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2 
-0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2 
-0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2 
-0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
-0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2 
-0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2 
+0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2
+0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2
+0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2
+0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2
+0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
+0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -2186,11 +2186,11 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
@@ -2198,7 +2198,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 #101 CH3I_SEAWATER  $ROOT/CH3I/v2014-07/ocean_ch3i.geos.4x5.nc       CH3I_OCEAN 1985/1-12/1/0 C xy kg/m3 CH3I - 1 1
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 101 ALD2_SEAWATER   $ROOT/ALD2/v2017-03/ALD2_seawater.geos.2x25.nc   ALD2       1985/1-12/1/0 C xy kg/m3 ALD2 - 1 1
 
 #==============================================================================
@@ -2252,24 +2252,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -2310,7 +2310,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -2331,7 +2331,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -2352,17 +2352,17 @@ Warnings:                    {WARNINGS}
 )))FINN_daily
 
 #==============================================================================
-# --- Inorganic iodine emissions (Extension 115) 
+# --- Inorganic iodine emissions (Extension 115)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -2516,7 +2516,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -2844,7 +2844,7 @@ Warnings:                    {WARNINGS}
 * UCX_LOSS_AERI     $ROOT/UCX/v2018-02/UCX_ProdLoss.v11-02d.4x5.72L.nc PORL_L_S__LAERI     2013/1-12/1/0 C xyz molec/cm3/s AERI     - 1  1
 
 # Archived OH concentrations. These are always needed, so set species to wildcard (*) to make
-# sure that this entry will always be read. 
+# sure that this entry will always be read.
 * STRAT_OH            $ROOT/GMI/v2015-02/gmi.clim.OH.geos5.2x25.nc             species 2000/1-12/1/0 C xyz v/v   *        - 1  1
 )))+LinStratChem+
 
@@ -2859,7 +2859,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -3125,20 +3125,20 @@ Warnings:                    {WARNINGS}
 # --- Inputs for the RRTMG radiative transfer model ---
 #
 # These fields will only be read if the +RRTMG+ toggle is activated.
-# +RRTMG+ can be set explicitly above as a setting of the base extension 
-# (--> +RRTMG+: true/false). If not defined, it will be set automatically 
+# +RRTMG+ can be set explicitly above as a setting of the base extension
+# (--> +RRTMG+: true/false). If not defined, it will be set automatically
 # based on the RRTMG toggle in input.geos (recommended).
 #
-# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce 
+# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce
 # differences at the level of numerical noise when comparing output to
 # simulations from prior versions (esp. when running at 4 x 5 resolution).
 # You might see larger differences w/r/t prior verisons for a few grid boxes
 # along the coastline of Antarctica, where the difference in resolution
-# and regridding will be more apparent in the sharp transition from ice to 
+# and regridding will be more apparent in the sharp transition from ice to
 # ocean.  If this is a problem, you can use the data files at 4x5 resolution
 # for 4x5 RRTMG simulations.
 #
-# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is 
+# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is
 # likely different than what was implemented when reading the old bpch
 # data from disk.  This can also cause differences when comparing to
 # prior versions.
@@ -3175,7 +3175,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -3212,16 +3212,16 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
 # --- day-of-week scale factors ---
-# ==> data is Sun/Mon/.../Sat 
+# ==> data is Sun/Mon/.../Sat
 #==============================================================================
-22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1 
+22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1
 
 #==============================================================================
 # --- seasonal scale factors ---
@@ -3234,9 +3234,9 @@ Warnings:                    {WARNINGS}
 39 BROMOCARB_SEASON $ROOT/BROMINE/v2015-02/BromoCarb_Season.nc CHXBRY_scale 2000/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -3321,22 +3321,22 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- BIOGENIC EMISSIONS FROM DRY LEAF MATTER ---
@@ -3355,17 +3355,17 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 101 AEICACET 3.693477e-3 - -  - xy unitless 1
@@ -3404,13 +3404,13 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1 
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 260 NEI11_PAR2ACET    0.06                                          - -               - xy 1 1
 261 NEI11_PAR2C3H8    0.03                                          - -               - xy 1 1
 262 NEI11_PAR2MEK     0.02                                          - -               - xy 1 1
@@ -3424,7 +3424,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -3448,7 +3448,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -3478,7 +3478,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.na
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.na
@@ -1005,14 +1005,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
-0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
-0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
-0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
-0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
-0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
-0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
-0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
-0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
+0 AF_EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0 AF_EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/1008/71         1 2
+0 AF_EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0 AF_EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/1008/71         1 2
+0 AF_EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0 AF_EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/1008/71         1 2
+0 AF_EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0 AF_EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.tropchem
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.tropchem
@@ -1001,6 +1001,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
+0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
+0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
+0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
+0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.tropchem
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.tropchem
@@ -6,16 +6,16 @@
 # !MODULE: HEMCO_Config.rc
 #
 # !DESCRIPTION: Contains configuration information for HEMCO. Define the
-#  emissions inventories and corresponding file paths here. Entire 
+#  emissions inventories and corresponding file paths here. Entire
 #  configuration files can be inserted into this configuration file with
-#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc' 
+#  an '>>>include' statement, e.g. '>>>include HEMCO\_Config\_test.rc'
 #  The settings of include-files will be ignored.
 #\\
 #\\
 # !REMARKS:
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -24,8 +24,8 @@
 #                as used in some filenames (e.g. "23L", "30L", "47L")
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
-# 
-# !REVISION HISTORY: 
+#
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
@@ -55,11 +55,11 @@ Warnings:                    {WARNINGS}
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 ###
-### This section lists all emission extensions available to HEMCO and whether 
-### they shall be used or not. Extension 'base' must have extension number 
-### zero, all other extension numbers can be freely chosen. Data fields in 
-### section 'base emissions' will only be read if the corresponding extension 
-### (identified by ExtNr) is enabled. Similarly, fields grouped into data 
+### This section lists all emission extensions available to HEMCO and whether
+### they shall be used or not. Extension 'base' must have extension number
+### zero, all other extension numbers can be freely chosen. Data fields in
+### section 'base emissions' will only be read if the corresponding extension
+### (identified by ExtNr) is enabled. Similarly, fields grouped into data
 ### collections ('(((CollectionName', ')))CollectionName') are only considered
 ### if the corresponding data collection is enabled in this section. Data
 ### listed within a disabled extension are always ignored, even if they are
@@ -70,17 +70,17 @@ Warnings:                    {WARNINGS}
 ### collection name is *not* enabled. This is achieved by leading the
 ### collection name with '.not.', e.g. '(((.not.FINN_daily' ...
 ### '))).not.FINN_daily' for FINN monthly data (only used if daily data is
-### not being used). 
+### not being used).
 ###
 ### The ExtNr provided in this section must match with the ExtNr assigned to
-### the data listed in the base emissions sections. Otherwise, the listed 
+### the data listed in the base emissions sections. Otherwise, the listed
 ### files won't be read!
 ###
 ### NOTES:
 ### --> You can only select one biomass burning option (GFED, QFED2, FINN, GFAS).
 ###
 ### --> The NAP scale factor is determined as in the original simulation:
-###     Obtain NAP emissions using scale factor from Hays 2002 ES&T 
+###     Obtain NAP emissions using scale factor from Hays 2002 ES&T
 ###     (0.0253 g NAP/kg DM) and Andreae and Merlet 2001 GBC (92 g CO/kg DM)
 ###
 ### --> You can select either NEI2011_HOURLY or NEI2011_MONMEAN but not both.
@@ -89,7 +89,7 @@ Warnings:                    {WARNINGS}
 # ExtNr ExtName                on/off  Species
 0       Base                   : on    *
 # ----- RESTART FIELDS ----------------------
-    --> GC_RESTART             :       true	
+    --> GC_RESTART             :       true
     --> HEMCO_RESTART          :       true
 # ----- REGIONAL INVENTORIES ----------------
     --> APEI                   :       true
@@ -98,7 +98,7 @@ Warnings:                    {WARNINGS}
     --> NEI2011_SHIP_HOURLY    :       false
     --> NEI2011_SHIP_MONMEAN   :       false
     --> MIX                    :       true
-    --> DICE_Africa            :       true 
+    --> DICE_Africa            :       true
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -115,7 +115,7 @@ Warnings:                    {WARNINGS}
     --> DECAYING_PLANTS        :       true
     --> AFCID                  :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -131,19 +131,19 @@ Warnings:                    {WARNINGS}
     --> MODIS_XLAI             :       true
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
-100     Custom                 : off   - 
+100     Custom                 : off   -
 101     SeaFlux                : on    DMS/ACET/ALD2
 102     ParaNOx                : on    NO/NO2/O3/HNO3
     --> LUT data format        :       nc
     --> LUT source dir         :       $ROOT/PARANOX/v2015-02
 103     LightNOx               : on    NO
     --> CDF table              :       $ROOT/LIGHTNOX/v2014-07/light_dist.ott2010.dat
-104     SoilNOx                : off   NO 
+104     SoilNOx                : off   NO
     --> Use fertilizer NOx     :       true
-105     DustDead               : off   DST1/DST2/DST3/DST4 
+105     DustDead               : off   DST1/DST2/DST3/DST4
 106     DustGinoux             : off   DST1/DST2/DST3/DST4
 107     SeaSalt                : off   SALA/SALC/Br2/BrSALA/BrSALC
-    --> SALA lower radius      :       0.01 
+    --> SALA lower radius      :       0.01
     --> SALA upper radius      :       0.5
     --> SALC lower radius      :       0.5
     --> SALC upper radius      :       8.0
@@ -152,7 +152,7 @@ Warnings:                    {WARNINGS}
     --> Model sea salt Br-     :       false
     --> Br- mass ratio         :       2.11e-3
 108     MEGAN                  : off   ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
     --> Isoprene to SOAP       :       0.015
@@ -183,7 +183,7 @@ Warnings:                    {WARNINGS}
     --> hydrophilic BC         :       0.2
     --> hydrophilic OC         :       0.5
 115     DustAlk                : off   DSTAL1/DSTAL2/DSTAL3/DSTAL4
-116     MarinePOA              : off   MOPO/MOPI 
+116     MarinePOA              : off   MOPO/MOPI
 117     Volcano                : on    SO2
     --> Volcano_Source         :       AeroCom
     --> Volcano_Table          :       $ROOT/VOLCANO/v2019-08/$YYYY/$MM/so2_volcanic_emissions_Carns.$YYYY$MM$DD.rc
@@ -193,7 +193,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -699,27 +699,27 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc  CO      2013/1/1/0 C xy g/m2/yr  CO    26/1008         1 60
 0 DICE_CARS_SOAP  -                                                                 -       -          - -  -        SOAP  26/1008/280     1 60
@@ -745,7 +745,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CARS_OCPO  -                                                                 -       -          - -  -        OCPO  73/1008/330     1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc  CO     2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_MOTORCYCLES_SOAP  -                                                                        -      -          - -  -        SOAP  26/1008/280      1 60
@@ -766,7 +766,7 @@ Warnings:                    {WARNINGS}
 0 DICE_MOTORCYCLES_OCPO  -                                                                        -      -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc  CO   2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_BACKUPGEN_SOAP  -                                                                          -    -          - -  -        SOAP  26/1008/280      1 60
@@ -794,7 +794,7 @@ Warnings:                    {WARNINGS}
 0 DICE_BACKUPGEN_OCPO  -                                                                          -        -          - -  -    OCPO  73/1008          1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008/320      1 60
 0 DICE_CHARCOALPROD_SOAP  -                                                                                -     -          - -  -        SOAP  26/1008/280/320  1 60
@@ -815,7 +815,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALPROD_OCPO  -                                                                                -     -          - -  -        OCPO  73/1008/320      1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_GASFLARE_SOAP  -                                                                       -     -          - -  -        SOAP  26/1008/280      1 60
@@ -833,7 +833,7 @@ Warnings:                    {WARNINGS}
 0 DICE_GASFLARE_OCPO  -                                                                       -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_AGBURNING_SOAP  -                                                                                       -     -          - -  -        SOAP  26/1008/280      2 60
@@ -871,7 +871,7 @@ Warnings:                    {WARNINGS}
 0 DICE_AGBURNING_OCPO  -                                                                                       -     -          - -  g/m2/yr  OCPO  73/1008          2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_CHARCOALUSE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      2 60
@@ -891,7 +891,7 @@ Warnings:                    {WARNINGS}
 0 DICE_CHARCOALUSE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_KEROSENE_SOAP  -                                                                         -     -          - -  -        SOAP  26/1008/280      1 60
@@ -901,7 +901,7 @@ Warnings:                    {WARNINGS}
 0 DICE_KEROSENE_OCPO  -                                                                         -     -          - -  -        OCPO  73/1008          1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          1 60
 0 DICE_OILREFINING_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      1 60
@@ -926,7 +926,7 @@ Warnings:                    {WARNINGS}
 0 DICE_OILREFINING_OCPO  -                                                                               -     -          - -  -        OCPO  73/1008          1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_HOUSEFUELWOOD_SOAP  -                                                                                   -     -          - -  -        SOAP  26/1008/280      2 60
@@ -961,7 +961,7 @@ Warnings:                    {WARNINGS}
 0 DICE_HOUSEFUELWOOD_OCPO  -                                                                                   -     -          - -  -        OCPO  73/1008          2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO    $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc  CO    2013/1/1/0 C xy g/m2/yr  CO    26/1008          2 60
 0 DICE_OTHERFUELWOOD_SOAP  -                                                                               -     -          - -  -        SOAP  26/1008/280      2 60
@@ -1052,6 +1052,9 @@ Warnings:                    {WARNINGS}
 0 AF_EDGAR_OCPO_SWD -                                                    -       -               - -  -       OCPO 1211/1008/73         1 60
 0 AF_EDGAR_POG1_SWD -                                                    -       -               - -  -       POG1 1211/1008/74/76      1 60
 0 AF_EDGAR_POG2_SWD -                                                    -       -               - -  -       POG2 1211/1008/74/77      1 60
+
+
+
 
 0 AF_EDGAR_SO2_POW  $ROOT/EDGARv43/v2016-11/EDGAR_v43.SO2.POW.0.1x0.1.nc emi_so2 1970-2010/1/1/0 C xy kg/m2/s SO2  1201/1008            1 60
 0 AF_EDGAR_SO4_POW  -                                                    -       -               - -  -       SO4  1201/1008/63         1 60
@@ -1314,10 +1317,10 @@ Warnings:                    {WARNINGS}
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #  * CEDS VOC emissions
-# 
+#
 # Aviation and shipping emissions from EDGAR are not included here.
 # We also do not include the following sources:
-#  - Soil emissions of NOx (SOL). These emissions are calculated via the 
+#  - Soil emissions of NOx (SOL). These emissions are calculated via the
 #    SoilNOx extension.
 #  - Open biomass burning (AWB). These emissions are obtained from
 #    GFED, QFED, FINN, or GFAS.
@@ -1454,7 +1457,7 @@ Warnings:                    {WARNINGS}
 0  EDGAR_pFe_FFF  -                                                    -       -               - -  -       pFe  1212/66         1 2
 
 #==============================================================================
-# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ --- 
+# --- NAP ANTHROPOGENIC EMISSIONS: approximate from EDGAR BENZ ---
 #
 # NOTE: Although this data comes from EDGAR version 2, we are storing it
 # in the EDGARv42 data path for convenience.
@@ -1677,10 +1680,10 @@ Warnings:                    {WARNINGS}
 # NOTES:
 # - These C2H6 emissions are used in place of CEDS
 #==============================================================================
-(((C2H6_2010 
+(((C2H6_2010
 0 C2H6_2010_oilgas   $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc ANTHR_C2H6   2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
 0 C2H6_2010_biofuel  $ROOT/C2H6_2010/v2019-06/C2H6_global_anth_biof.2010$MM.4x5.nc BIOFUEL_C2H6 2010/1-12/1/0 C xy kgC/m2/s C2H6 - 1 100
-)))C2H6_2010 
+)))C2H6_2010
 
 #==============================================================================
 # --- Xiao et al., JGR, 2008 ---
@@ -1836,9 +1839,9 @@ Warnings:                    {WARNINGS}
 #------------------------------------------------------------------------------
 # ### IF THE PARANOX EXTENSION IS TURNED ON ###
 #
-# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension 
-# number (# 102) to specify these quantities and the NEI emissions.  
-# This will make sure everything will be passed to the HEMCO PARANOX extension 
+# Cosine(SZA) will be read from the restart file.  Use the PARANOX extension
+# number (# 102) to specify these quantities and the NEI emissions.
+# This will make sure everything will be passed to the HEMCO PARANOX extension
 # rather than sending them into the base emissions.
 #------------------------------------------------------------------------------
 102  ICOADS_SHIP_NO    $ROOT/ICOADS_SHIP/v2014-07/ICOADS.generic.1x1.nc                NO     2002/1-12/1/0          C xy kg/m2/s  NO   1/5      10 1
@@ -1896,19 +1899,19 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 (((AEIC
 0 AEIC_NO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  NO2      2005/1-12/1/0 C xyz kg/m2/s NO   110/115 20 1
-0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1 
-0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1 
-0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1 
-0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1 
-0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1 
-0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1 
+0 AEIC_CO   $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  CO       2005/1-12/1/0 C xyz kg/m2/s CO   110     20 1
+0 AEIC_SOAP -                                        -        -             - -   -       SOAP 110/280 20 1
+0 AEIC_SO2  $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  FUELBURN 2005/1-12/1/0 C xyz kg/m2/s SO2  111     20 1
+0 AEIC_SO4  -                                        -        -             - -   -       SO4  112     20 1
+0 AEIC_BCPI -                                        -        -             - -   -       BCPI 113     20 1
+0 AEIC_OCPI -                                        -        -             - -   -       OCPI 113     20 1
 0 AEIC_ACET $ROOT/AEIC/v2015-01/AEIC.47L.gen.1x1.nc  HC       2005/1-12/1/0 C xyz kg/m2/s ACET 114/101 20 1
 0 AEIC_ALD2 -                                        -        -             - -   -       ALD2 114/102 20 1
-0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1  
+0 AEIC_ALK4 -                                        -        -             - -   -       ALK4 114/103 20 1
 0 AEIC_C2H6 -                                        -        -             - -   -       C2H6 114/104 20 1
 0 AEIC_C3H8 -                                        -        -             - -   -       C3H8 114/105 20 1
 0 AEIC_CH2O -                                        -        -             - -   -       CH2O 114/106 20 1
-0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1 
+0 AEIC_PRPE -                                        -        -             - -   -       PRPE 114/107 20 1
 0 AEIC_MACR -                                        -        -             - -   -       MACR 114/108 20 1
 0 AEIC_RCHO -                                        -        -             - -   -       RCHO 114/109 20 1
 )))AEIC
@@ -1951,7 +1954,7 @@ Warnings:                    {WARNINGS}
 0 RCP3PD_HCOOH   $ROOT/RCP/v2015-02/RCP_3PD/RCPs_anthro_total_acids_2005-2100_23474.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_3PD
 
-(((RCP_45 
+(((RCP_45
 0 RCP45_CH4     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CH4_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP45_NOx     $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_NOx_2005-2100_27424.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP45_CO      $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_CO_2005-2100_27424.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -1978,7 +1981,7 @@ Warnings:                    {WARNINGS}
 0 RCP45_HCOOH   $ROOT/RCP/v2015-02/RCP_45/RCPs_anthro_total_acids_2005-2100_27424.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_45
 
-(((RCP_60 
+(((RCP_60
 0 RCP60_CH4     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CH4_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP60_NOx     $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_NOx_2005-2100_43190.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP60_CO      $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_CO_2005-2100_43190.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2005,7 +2008,7 @@ Warnings:                    {WARNINGS}
 0 RCP60_HCOOH   $ROOT/RCP/v2015-02/RCP_60/RCPs_anthro_total_acids_2005-2100_43190.nc                    ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  HCOOH 57/58 1 1
 )))RCP_60
 
-(((RCP_85 
+(((RCP_85
 0 RCP85_CH4     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CH4_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CH4   -     1 1
 0 RCP85_NOx     $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_NOx_2005-2100_43533.nc                            ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  NO    -     1 1
 0 RCP85_CO      $ROOT/RCP/v2015-02/RCP_85/RCPs_anthro_CO_2005-2100_43533.nc                             ACCMIP 2005-2100/1/1/0 I xy kg/m2/s  CO    -     1 1
@@ -2036,44 +2039,44 @@ Warnings:                    {WARNINGS}
 # --- QFED2 biomass burning (v2.5r1) ---
 #==============================================================================
 (((QFED2
-0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2 
-0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2 
-0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2 
-0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2 
-0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2 
-0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2 
-0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2 
+0 QFED_ACET_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ACET 75/311        5 2
+0 QFED_ACET_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_acet.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ACET 75/312        5 2
+0 QFED_ALD2_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALD2 75/311        5 2
+0 QFED_ALD2_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ald2.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALD2 75/312        5 2
+0 QFED_ALK4_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s ALK4 75/311        5 2
+0 QFED_ALK4_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_alk4.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s ALK4 75/312        5 2
+0 QFED_BCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s BCPI 70/75/311     5 2
 0 QFED_BCPO_PBL  -                                                                 -       -                     - -             -       BCPO 71/75/311     5 2
-0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2 
-0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2 
-0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2 
-0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2 
-0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2 
-0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2 
-0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2 
-0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2 
-0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2 
-0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2 
-0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2 
-0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2 
-0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2 
-0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2 
-0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2 
+0 QFED_BCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_bc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s BCPI 70/75/312     5 2
+0 QFED_BCPO_FT   -                                                                 -       -                     - -             -       BCPO 71/75/312     5 2
+0 QFED_OCPI_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s OCPI 72/75/311     5 2
+0 QFED_OCPO_PBL  -                                                                 -       -                     - -             -       OCPO 73/75/311     5 2
+0 QFED_OCPI_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_oc.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s OCPI 72/75/312     5 2
+0 QFED_OCPO_FT   -                                                                 -       -                     - -             -       OCPO 73/75/312     5 2
+0 QFED_C2H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C2H6 75/311        5 2
+0 QFED_C2H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c2h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C2H6 75/312        5 2
+0 QFED_C3H8_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s C3H8 75/311        5 2
+0 QFED_C3H8_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h8.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s C3H8 75/312        5 2
+0 QFED_CH2O_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH2O 75/311        5 2
+0 QFED_CH2O_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch2o.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH2O 75/312        5 2
+0 QFED_CH4_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CH4  75/311        5 2
+0 QFED_CH4_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_ch4.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CH4  75/312        5 2
+0 QFED_CO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO   54/75/311     5 2
 0 QFED_SOAP_PBL  -                                                                 -       -                     - -             -       SOAP 54/75/281/311 5 2
-0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2 
+0 QFED_CO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO   54/75/312     5 2
 0 QFED_SOAP_FT   -                                                                 -       -                     - -             -       SOAP 54/75/281/312 5 2
-0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2 
-0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2 
-0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2 
-0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2 
-0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2 
-0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2 
-0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2 
-0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2 
-0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2 
-0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2 
-0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2 
-0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2 
+0 QFED_CO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO2  75/311        5 2
+0 QFED_CO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO2  75/312        5 2
+0 QFED_MEK_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s MEK  75/311        5 2
+0 QFED_MEK_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_mek.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s MEK  75/312        5 2
+0 QFED_NH3_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NH3  75/311        5 2
+0 QFED_NH3_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_nh3.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NH3  75/312        5 2
+0 QFED_NO_PBL    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s NO   75/311        5 2
+0 QFED_NO_FT     $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_no.006.$YYYY$MM$DD.nc4   biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s NO   75/312        5 2
+0 QFED_SO2_PBL   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s SO2  75/311        5 2
+0 QFED_SO2_FT    $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_so2.006.$YYYY$MM$DD.nc4  biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s SO2  75/312        5 2
+0 QFED_C3H6_PBL  $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s PRPE 75/311        5 2
+0 QFED_C3H6_FT   $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_c3h6.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s PRPE 75/312        5 2
 )))QFED2
 
 #==============================================================================
@@ -2182,11 +2185,11 @@ Warnings:                    {WARNINGS}
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
@@ -2194,7 +2197,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 #101 CH3I_SEAWATER  $ROOT/CH3I/v2014-07/ocean_ch3i.geos.4x5.nc       CH3I_OCEAN 1985/1-12/1/0 C xy kg/m3 CH3I - 1 1
 101 DMS_SEAWATER    $ROOT/DMS/v2015-07/DMS_lana.geos.1x1.nc          DMS_OCEAN  1985/1-12/1/0 C xy kg/m3 DMS  - 1 1
-101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1 
+101 ACET_SEAWATER   $ROOT/ACET/v2014-07/ACET_seawater.generic.1x1.nc ACET       2005/1/1/0    C xy kg/m3 ACET - 1 1
 101 ALD2_SEAWATER   $ROOT/ALD2/v2017-03/ALD2_seawater.geos.2x25.nc   ALD2       1985/1-12/1/0 C xy kg/m3 ALD2 - 1 1
 
 #==============================================================================
@@ -2248,24 +2251,24 @@ Warnings:                    {WARNINGS}
 105 DEAD_VAI        $ROOT/DUST_DEAD/v2019-06/dst_tvbds.geos.4x5.nc                  VAI      1985/1-12/1/0 C xy unitless *    -    1 1
 
 #==============================================================================
-# --- Dust emissions using Paul Ginoux's mechanism (Extension 106) 
+# --- Dust emissions using Paul Ginoux's mechanism (Extension 106)
 #==============================================================================
-106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1 
-106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1 
+106 GINOUX_SAND   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SAND  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_SILT   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  SILT  1985/1/1/0 C xy unitless * - 1 1
+106 GINOUX_CLAY   $ROOT/DUST_GINOUX/v2014-07/NSP.dust.geos.4x5.nc  CLAY  1985/1/1/0 C xy unitless * - 1 1
 
 #==============================================================================
-# --- Sea salt emissions (Extension 107) 
+# --- Sea salt emissions (Extension 107)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -2306,7 +2309,7 @@ Warnings:                    {WARNINGS}
 109  MEGAN_ORVC                   $ROOT/SOA/v2014-07/NVOC.geos.1x1.nc                     OCPI                    1990/1-12/1/0     C xy kgC/m2/s * - 1 1
 
 #==============================================================================
-# --- GFED biomass burning emissions (Extension 111) 
+# --- GFED biomass burning emissions (Extension 111)
 # NOTE: These are the base emissions in kgDM/m2/s.
 #==============================================================================
 (((GFED4
@@ -2327,7 +2330,7 @@ Warnings:                    {WARNINGS}
 )))GFED4
 
 #==============================================================================
-# --- FINN v1.5 biomass burning emissions (Extension 114) 
+# --- FINN v1.5 biomass burning emissions (Extension 114)
 #==============================================================================
 (((.not.FINN_daily
 114 FINN_VEGTYP1       $ROOT/FINN/v2015-02/FINN_monthly_$YYYY_0.25x0.25.compressed.nc fire_vegtype1 2002-2016/1-12/1/0 RF xy kg/m2/s * - 1 1
@@ -2348,17 +2351,17 @@ Warnings:                    {WARNINGS}
 )))FINN_daily
 
 #==============================================================================
-# --- Inorganic iodine emissions (Extension 115) 
+# --- Inorganic iodine emissions (Extension 115)
 #==============================================================================
-# --- No external data --- 
+# --- No external data ---
 
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -2505,7 +2508,7 @@ Warnings:                    {WARNINGS}
 * TOMS_O3_COL   $ROOT/TOMS_SBUV/v2019-06/TOMS_O3col_$YYYY.a.geos.1x1.nc TOMS   1971-2010/1-12/1/0 CY xy dobsons     * - 1 1
 * TOMS1_O3_COL  -                                                       TOMS1  -                  -  -  dobsons/day * - 1 1
 * TOMS2_O3_COL  -                                                       TOMS2  -                  -  -  dobsons/day * - 1 1
-* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1 
+* DTOMS1_O3_COL -                                                       DTOMS1 -                  -  -  dobsons/day * - 1 1
 * DTOMS2_O3_COL -                                                       DTOMS2 -                  -  -  dobsons/day * - 1 1
 )))+TOMS_SBUV_O3+
 
@@ -2833,7 +2836,7 @@ Warnings:                    {WARNINGS}
 * UCX_LOSS_AERI     $ROOT/UCX/v2018-02/UCX_ProdLoss.v11-02d.4x5.72L.nc PORL_L_S__LAERI     2013/1-12/1/0 C xyz molec/cm3/s AERI     - 1  1
 
 # Archived OH concentrations. These are always needed, so set species to wildcard (*) to make
-# sure that this entry will always be read. 
+# sure that this entry will always be read.
 * STRAT_OH            $ROOT/GMI/v2015-02/gmi.clim.OH.geos5.2x25.nc             species 2000/1-12/1/0 C xyz v/v   *        - 1  1
 )))+LinStratChem+
 
@@ -2848,7 +2851,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -3114,20 +3117,20 @@ Warnings:                    {WARNINGS}
 # --- Inputs for the RRTMG radiative transfer model ---
 #
 # These fields will only be read if the +RRTMG+ toggle is activated.
-# +RRTMG+ can be set explicitly above as a setting of the base extension 
-# (--> +RRTMG+: true/false). If not defined, it will be set automatically 
+# +RRTMG+ can be set explicitly above as a setting of the base extension
+# (--> +RRTMG+: true/false). If not defined, it will be set automatically
 # based on the RRTMG toggle in input.geos (recommended).
 #
-# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce 
+# NOTE: The 2 x 2.5 albedo fields and emissivity fields will produce
 # differences at the level of numerical noise when comparing output to
 # simulations from prior versions (esp. when running at 4 x 5 resolution).
 # You might see larger differences w/r/t prior verisons for a few grid boxes
 # along the coastline of Antarctica, where the difference in resolution
-# and regridding will be more apparent in the sharp transition from ice to 
+# and regridding will be more apparent in the sharp transition from ice to
 # ocean.  If this is a problem, you can use the data files at 4x5 resolution
 # for 4x5 RRTMG simulations.
 #
-# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is 
+# ALSO NOTE: The algorithm that HEMCO uses to select each time slice is
 # likely different than what was implemented when reading the old bpch
 # data from disk.  This can also cause differences when comparing to
 # prior versions.
@@ -3164,7 +3167,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -3201,16 +3204,16 @@ Warnings:                    {WARNINGS}
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 25 EDGAR_TODNOX $ROOT/EDGARv42/v2015-02/NO/EDGAR_hourly_NOxScal.nc NOXscale 2000/1/1/* C xy unitless 1
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy unitless 1
 
 #==============================================================================
 # --- day-of-week scale factors ---
-# ==> data is Sun/Mon/.../Sat 
+# ==> data is Sun/Mon/.../Sat
 #==============================================================================
-22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1 
+22 GEIA_DOW_HC  0.671/1.1102/1.1102/1.1102/1.1102/1.1102/0.768 - - - xy unitless 1
 
 #==============================================================================
 # --- seasonal scale factors ---
@@ -3223,9 +3226,9 @@ Warnings:                    {WARNINGS}
 39 BROMOCARB_SEASON $ROOT/BROMINE/v2015-02/BromoCarb_Season.nc CHXBRY_scale 2000/1-12/1/0 C xy unitless 1
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -3310,22 +3313,22 @@ Warnings:                    {WARNINGS}
 
 # NAPTOTSCAL: factor to scale total NAP emissions to POA (hotp 7/24/09)
 #REAL*8, PARAMETER    :: NAPTOTALSCALE = 66.09027d0
- 
-# = CO emissions * emissions ratio of mol NAP / mol CO 
-# * kg C / mol NAP * mol CO / kg CO 
-# mmol NAP / mol CO = 0.025 g NAP/ kg DM / 
+
+# = CO emissions * emissions ratio of mol NAP / mol CO
+# * kg C / mol NAP * mol CO / kg CO
+# mmol NAP / mol CO = 0.025 g NAP/ kg DM /
 #              ( 78 g CO/ kg DM ) * 28 g CO / mol CO
 #            / ( 128 g NAP / mol NAP ) *1000 mmol/mol
 # scale emissions down if appropriate to remove the
 # effect of VOC ox on CO emission
 # EF for NAP from Andreae and Merlet 2001 Glob Biog Cyc
 # EF for CO  from Andreae and Merlet 2001 Glob Biog Cyc
-#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3 
+#BIOFUEL_KG(N,:,:) = BIOFUEL_KG(IDBFCO,:,:) * 0.0701d-3
 #                  * 120d0 / 28d0 * COSCALEDOWN
 #==============================================================================
 80 NAPEMISS   1.0     - - - xy unitless 1
 81 NAPTOTSCAL 66.09   - - - xy unitless 1
-82 BENZTONAP  6.86e-2 - - - xy unitless 1 
+82 BENZTONAP  6.86e-2 - - - xy unitless 1
 
 #==============================================================================
 # --- BIOGENIC EMISSIONS FROM DRY LEAF MATTER ---
@@ -3344,17 +3347,17 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 101 AEICACET 3.693477e-3 - -  - xy unitless 1
@@ -3393,13 +3396,13 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- NEI 2011 scale factors ---
 #==============================================================================
-251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1 
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
-253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1 
-254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1 
-255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1 
-256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
-257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1 
+251 NEI11_NO_YRSCALE  1.337/1.255/1.172/1.097/1.034/1.0/0.939/0.887 - 2006-2013/1/1/0 C xy 1 1
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
+253 NEI11_NH3_YRSCALE 0.966/1.002/1.019/1.015/1.010/1.0/0.999/0.998 - 2006-2013/1/1/0 C xy 1 1
+254 NEI11_VOC_YRSCALE 1.083/1.093/1.011/1.000/1.016/1.0/0.986/0.971 - 2006-2013/1/1/0 C xy 1 1
+255 NEI11_SO2_YRSCALE 2.038/1.813/1.600/1.408/1.200/1.0/0.800/0.738 - 2006-2013/1/1/0 C xy 1 1
+256 NEI11_BC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
+257 NEI11_OC_YRSCALE  1.006/1.034/0.996/0.995/0.993/1.0/0.995/0.991 - 2006-2013/1/1/0 C xy 1 1
 260 NEI11_PAR2ACET    0.06                                          - -               - xy 1 1
 261 NEI11_PAR2C3H8    0.03                                          - -               - xy 1 1
 262 NEI11_PAR2MEK     0.02                                          - -               - xy 1 1
@@ -3413,7 +3416,7 @@ Warnings:                    {WARNINGS}
 #==============================================================================
 # --- SOA-Precursor scale factors ---
 #
-# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends 
+# from Kim, P.S., et. al. 2015 "Sources, seasonality, and trends
 # of southeast US aerosol: ..."
 #
 #   AVOCs and BBVOCs are emitted in proportion to CO, with an emission ratio of
@@ -3437,7 +3440,7 @@ Warnings:                    {WARNINGS}
 # by a factor of 5 after finding error in implementation of emission factors.
 #==============================================================================
 320 DICE_CP_SF    0.20 - - - xy 1 1
- 
+
 #==============================================================================
 # DICE-Africa car emissions of OCPI and OCPO scale factor to address a factor of 7 overestimate
 # in car OC emissions that results from incorrect emission factors used in the original inventory
@@ -3467,7 +3470,7 @@ Warnings:                    {WARNINGS}
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2

--- a/runs/shared_inputs/fullchem/HEMCO_Config.template.tropchem
+++ b/runs/shared_inputs/fullchem/HEMCO_Config.template.tropchem
@@ -1001,14 +1001,14 @@ Warnings:                    {WARNINGS}
 # ---------------------------------------------------
 0 AF_EDGAR_BCPI_POW $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.POW.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1201/1008/70         1 60
 0 AF_EDGAR_BCPO_POW -                                                    -       -               - -  -       BCPO 1201/1008/71         1 60
-0  EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
-0  EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/71         1 2
-0  EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
-0  EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/71         1 2
-0  EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
-0  EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/71         1 2
-0  EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
-0  EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
+0 AF_EDGAR_BCPI_ENG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.ENG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1202/1008/70         1 2
+0 AF_EDGAR_BCPO_ENG -                                                    -       -               - -  -       BCPO 1202/1008/71         1 2
+0 AF_EDGAR_BCPI_IND $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.IND.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1203/1008/70         1 2
+0 AF_EDGAR_BCPO_IND -                                                    -       -               - -  -       BCPO 1203/1008/71         1 2
+0 AF_EDGAR_BCPI_TNG $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.TNG.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1205/1008/70         1 2
+0 AF_EDGAR_BCPO_TNG -                                                    -       -               - -  -       BCPO 1205/1008/71         1 2
+0 AF_EDGAR_BCPI_SWD $ROOT/EDGARv43/v2016-11/EDGAR_v43.BC.SWD.0.1x0.1.nc  emi_bc  1970-2010/1/1/0 C xy kg/m2/s BCPI 1211/1008/70         1 2
+0 AF_EDGAR_BCPO_SWD -                                                    -       -               - -  -       BCPO 1211/1008/71         1 2
 
 0 AF_EDGAR_CO_POW   $ROOT/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc  emi_co  1970-2010/1/1/0 C xy kg/m2/s CO   1201/26/52/1008      1 60
 0 AF_EDGAR_SOAP_POW -                                                    -       -               - -  -       SOAP 1201/26/52/1008/280  1 60

--- a/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.benchmark
+++ b/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.benchmark
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------------
 #BOP
 #
-# !MODULE: HEMCO_Diagn.rc 
+# !MODULE: HEMCO_Diagn.rc
 #
 # !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
 #\\
@@ -15,7 +15,7 @@
 #  For a list of species by inventory, please see:
 #  http://wiki.geos-chem.org/HEMCO_data_directories#Default_GEOS-Chem_emissions_configurations
 #
-#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary, 
+#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary,
 #  you can convert hydrocarbon species to e.g. kg C/m2/s in post-processing.
 #
 #  The INVENTORY DIAGNOSTICS (starting with "Inv")  are only needed for
@@ -51,7 +51,7 @@ EmisALD2_PlantDecay ALD2  0      3   -1   2   kg/m2/s  ALD2_emission_flux_from_d
 EmisALD2_Ship      ALD2   0      10  -1   2   kg/m2/s  ALD2_emission_flux_from_ships
 
 ###############################################################################
-#####  ALK4 emissions                                                     ##### 
+#####  ALK4 emissions                                                     #####
 ###############################################################################
 EmisALK4_Total     ALK4   -1     -1  -1   3   kg/m2/s  ALK4_emission_flux_from_all_sectors
 EmisALK4_Aircraft  ALK4   0      20  -1   3   kg/m2/s  ALK4_emission_flux_from_aircraft
@@ -60,7 +60,7 @@ EmisALK4_BioBurn   ALK4   111    -1  -1   2   kg/m2/s  ALK4_emission_flux_from_b
 EmisALK4_Ship      ALK4   0      10  -1   2   kg/m2/s  ALK4_emission_flux_from_ships
 
 ###############################################################################
-#####  BCPI and BCPO emissions                                            ##### 
+#####  BCPI and BCPO emissions                                            #####
 ###############################################################################
 EmisBCPI_Total     BCPI   -1     -1  -1   3   kg/m2/s  BCPI_emission_flux_from_all_sectors
 EmisBCPI_Aircraft  BCPI   0      20  -1   3   kg/m2/s  BCPI_emission_flux_from_aircraft
@@ -73,7 +73,7 @@ EmisBCPO_BioBurn   BCPO   111    -1  -1   2   kg/m2/s  BCPO_emission_flux_from_b
 EmisBCPO_Ship      BCPO   0      10  -1   2   kg/m2/s  BCPO_emission_flux_from_ships
 
 ###############################################################################
-#####  BENZ emissions                                                     ##### 
+#####  BENZ emissions                                                     #####
 ###############################################################################
 EmisBENZ_Total     BENZ   -1     -1  -1   3   kg/m2/s  BENZ_emission_flux_from_all_sectors
 EmisBENZ_Anthro    BENZ   0      1   -1   3   kg/m2/s  BENZ_emission_flux_from_anthropogenic
@@ -105,7 +105,7 @@ EmisC2H6_BioBurn   C2H6   111    -1  -1   2   kg/m2/s  C2H6_emission_flux_from_b
 EmisC2H6_Ship      C2H6   0      10  -1   2   kg/m2/s  C2H6_emission_flux_from_ships
 
 ###############################################################################
-#####  C3H8 emissions                                                     ##### 
+#####  C3H8 emissions                                                     #####
 ###############################################################################
 EmisC3H8_Total     C3H8   -1     -1  -1   3   kg/m2/s  C3H8_emission_flux_from_all_sectors
 EmisC3H8_Aircraft  C3H8   0      20  -1   3   kg/m2/s  C3H8_emission_flux_from_aircraft
@@ -114,27 +114,27 @@ EmisC3H8_BioBurn   C3H8   111    -1  -1   2   kg/m2/s  C3H8_emission_flux_from_b
 EmisC3H8_Ship      C3H8   0      10  -1   2   kg/m2/s  C3H8_emission_flux_from_ships
 
 ###############################################################################
-#####  CH2Br2 emissions                                                   ##### 
+#####  CH2Br2 emissions                                                   #####
 ###############################################################################
 EmisCH2Br2_Ocean   CH2Br2 0      1   -1   2   kg/m2/s  CH2Br2_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2I2 emissions                                                   ##### 
+#####  CH2I2 emissions                                                   #####
 ###############################################################################
 EmisCH2I2_Ocean    CH2I2  0     1    -1   2   kg/m2/s  CH2I2_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2ICl emissions                                                   ##### 
+#####  CH2ICl emissions                                                   #####
 ###############################################################################
 EmisCH2ICl_Ocean   CH2ICl 0     1    -1   2   kg/m2/s  CH2ICl_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2IBr emissions                                                   ##### 
+#####  CH2IBr emissions                                                   #####
 ###############################################################################
 EmisCH2IBr_Ocean   CH2IBr 0     1    -1   2   kg/m2/s  CH2IBr_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2O emissions                                                     ##### 
+#####  CH2O emissions                                                     #####
 ###############################################################################
 EmisCH2O_Total     CH2O   -1     -1  -1   3   kg/m2/s  CH2O_emission_flux_from_all_sectors
 EmisCH2O_Aircraft  CH2O   0      20  -1   3   kg/m2/s  CH2O_emission_flux_from_aircraft
@@ -143,12 +143,12 @@ EmisCH2O_BioBurn   CH2O   111    -1  -1   2   kg/m2/s  CH2O_emission_flux_from_b
 EmisCH2O_Ship      CH2O   0      10  -1   2   kg/m2/s  CH2O_emission_flux_from_ships
 
 ###############################################################################
-#####  CH3I emissions                                                   ##### 
+#####  CH3I emissions                                                   #####
 ###############################################################################
 EmisCH3I_Ocean     CH3I   0     1    -1   2   kg/m2/s  CH3I_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH4 emissions                                                      ##### 
+#####  CH4 emissions                                                      #####
 ###############################################################################
 EmisCH4_Total      CH4    -1     -1  -1   3   kg/m2/s  CH4_emission_flux_from_all_sectors
 EmisCH4_Anthro     CH4    0      1   -1   3   kg/m2/s  CH4_emission_flux_from_anthropogenic
@@ -156,12 +156,12 @@ EmisCH4_BioBurn    CH4    0      5   -1   2   kg/m2/s  CH4_emission_flux_from_bi
 EmisCH4_Ship       CH4    0      10  -1   2   kg/m2/s  CH4_emission_flux_from_ships
 
 ###############################################################################
-#####  CHBr3 emissions                                                    ##### 
+#####  CHBr3 emissions                                                    #####
 ###############################################################################
 EmisCHBr3_Ocean    CHBr3  0      1   -1   2   kg/m2/s  CHBr3_emission_flux_from_ocean
 
 ###############################################################################
-#####  CO sources                                                         ##### 
+#####  CO sources                                                         #####
 ###############################################################################
 EmisCO_Total       CO     -1     -1  -1   3   kg/m2/s  CO_emission_flux_from_all_sectors
 EmisCO_Aircraft    CO     0      20  -1   3   kg/m2/s  CO_emission_flux_from_aircraft
@@ -170,7 +170,7 @@ EmisCO_BioBurn     CO     111    -1  -1   2   kg/m2/s  CO_emission_flux_from_bio
 EmisCO_Ship        CO     0      10  -1   2   kg/m2/s  CO_emission_flux_from_ships
 
 ###############################################################################
-#####  CO2 emissions                                                      ##### 
+#####  CO2 emissions                                                      #####
 ###############################################################################
 EmisCO2_Total      CO2    -1     -1  -1   3   kg/m2/s  CO2_emission_flux_from_all_sectors
 EmisCO2_Anthro     CO2    0      1   -1   3   kg/m2/s  CO2_emission_flux_from_anthropogenic
@@ -178,12 +178,12 @@ EmisCO2_BioBurn    CO2    0      5   -1   2   kg/m2/s  CO2_emission_flux_from_bi
 EmisCO2_Ship       CO2    0      10  -1   2   kg/m2/s  CO2_emission_flux_from_ships
 
 ###############################################################################
-#####  DMS emissions                                                      ##### 
+#####  DMS emissions                                                      #####
 ###############################################################################
 EmisDMS_Ocean      DMS    101    -1  -1   2   kg/m2/s  DMS_emission_flux_from_ocean
 
 ###############################################################################
-#####  Dust emissions                                                     ##### 
+#####  Dust emissions                                                     #####
 ###############################################################################
 EmisDST1_Total     DST1   -1     -1  -1   2   kg/m2/s  DST1_emission_flux_from_all_sectors
 EmisDST1_Anthro    DST1   0      1   -1   2   kg/m2/s  DST1_emission_flux_from_anthropogenic
@@ -193,7 +193,7 @@ EmisDST3_Natural   DST3   0      3   -1   2   kg/m2/s  DST3_emission_flux_from_n
 EmisDST4_Natural   DST4   0      3   -1   2   kg/m2/s  DST4_emission_flux_from_natural_sources
 
 ###############################################################################
-#####  EOH emissions                                                      ##### 
+#####  EOH emissions                                                      #####
 ###############################################################################
 EmisEOH_Total      EOH    -1     -1  -1   3   kg/m2/s  EOH_emission_flux_from_all_sectors
 EmisEOH_Anthro     EOH    0      1   -1   3   kg/m2/s  EOH_emission_flux_from_anthropogenic
@@ -203,25 +203,25 @@ EmisEOH_PlantDecay EOH    0      3   -1   2   kg/m2/s  EOH_emission_flux_from_de
 EmisEOH_Ship       EOH    0      10  -1   2   kg/m2/s  EOH_emission_flux_from_ships
 
 ###############################################################################
-#####  HAC emissions                                                     ##### 
+#####  HAC emissions                                                     #####
 ###############################################################################
 EmisHAC_Total      HAC    -1     -1  -1   3   kg/m2/s  HAC_emission_flux_from_all_sectors
 EmisHAC_Anthro     HAC    0      1   -1   3   kg/m2/s  HAC_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  GLYC emissions                                                     ##### 
+#####  GLYC emissions                                                     #####
 ###############################################################################
 EmisGLYC_Total     GLYC   -1     -1  -1   3   kg/m2/s  GLYC_emission_flux_from_all_sectors
 EmisGLYC_Anthro    GLYC   0      1   -1   3   kg/m2/s  GLYC_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  GLYX emissions                                                     ##### 
+#####  GLYX emissions                                                     #####
 ###############################################################################
 EmisGLYX_Total     GLYX   -1     -1  -1   3   kg/m2/s  GLYX_emission_flux_from_all_sectors
 EmisGLYX_Anthro    GLYX   0      1   -1   3   kg/m2/s  GLYX_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  HCOOH sources                                                      ##### 
+#####  HCOOH sources                                                      #####
 ###############################################################################
 EmisHCOOH_Total    HCOOH  -1     -1  -1   3   kg/m2/s  HCOOH_emission_flux_from_all_sectors
 EmisHCOOH_Anthro   HCOOH  0      1   -1   3   kg/m2/s  HCOOH_emission_flux_from_anthropogenic
@@ -250,7 +250,7 @@ EmisISOP_Biogenic  ISOP   0      4   -1   2   kg/m2/s  ISOP_emission_flux_from_b
 EmisLIMO_Biogenic  LIMO   0      4   -1   2   kg/m2/s  LIMO_emission_flux_from_biogenic_sources
 
 ###############################################################################
-#####  MACR emissions                                                     ##### 
+#####  MACR emissions                                                     #####
 ###############################################################################
 EmisMACR_Total     MACR   -1     -1  -1   3   kg/m2/s  MACR_emission_flux_from_all_sectors
 EmisMACR_Aircraft  MACR   0      20  -1   3   kg/m2/s  MACR_emission_flux_from_anthropogenic
@@ -265,7 +265,7 @@ EmisMEK_BioBurn    MEK    111    -1  -1   2   kg/m2/s  MEK_emission_flux_from_bi
 EmisMEK_Ship       MEK    0      10  -1   2   kg/m2/s  MEK_emission_flux_from_ships
 
 ###############################################################################
-#####  MGLY emissions                                                     ##### 
+#####  MGLY emissions                                                     #####
 ###############################################################################
 EmisMGLY_Total     MGLY   -1     -1  -1   3   kg/m2/s  MGLY_emission_flux_from_all_sectors
 EmisMGLY_Anthro    MGLY   0      1   -1   3   kg/m2/s  MGLY_emission_flux_from_anthropogenic
@@ -295,7 +295,7 @@ EmisMTPO_Biogenic  MTPO   0      4   -1   2   kg/m2/s  MTPO_emission_flux_from_b
 EmisMVK_Anthro     MVK    0      1   -1   3   kg/m2/s  MVK_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  NAP emissions                                                      ##### 
+#####  NAP emissions                                                      #####
 ###############################################################################
 EmisNAP_Total      NAP    -1     -1  -1   3   kg/m2/s  NAP_emission_flux_from_all_sectors
 EmisNAP_Anthro     NAP    0      1   -1   3   kg/m2/s  NAP_emission_flux_from_anthropogenic
@@ -323,18 +323,18 @@ EmisNO_Ship        NO     102    -1  -1   2   kg/m2/s  NO_emission_flux_from_shi
 EmisNO_Soil        NO     0      3   -1   2   kg/m2/s  NO_emission_flux_from_soil
 
 ###############################################################################
-#####  NO2 emissions                                                      ##### 
+#####  NO2 emissions                                                      #####
 ###############################################################################
 EmisNO2_Anthro     NO2    0      1   -1   3   kg/m2/s  NO2_emission_flux_from_anthropogenic
 EmisNO2_Ship       NO2    102    -1  -1   2   kg/m2/s  NO2_emission_flux_from_ships
 
 ###############################################################################
-#####  O3 emissions                                                       ##### 
+#####  O3 emissions                                                       #####
 ###############################################################################
 EmisO3_Ship        O3     102    -1  -1   2   kg/m2/s  O3_emission_flux_from_ships
 
 ###############################################################################
-#####  OCPI and OCPO emissions                                            ##### 
+#####  OCPI and OCPO emissions                                            #####
 ###############################################################################
 EmisOCPI_Total     OCPI   -1     -1  -1   3   kg/m2/s  OCPI_emission_flux_from_all_sectors
 EmisOCPI_Aircraft  OCPI   0      20  -1   3   kg/m2/s  OCPI_emission_flux_from_aircraft
@@ -347,14 +347,14 @@ EmisOCPO_BioBurn   OCPO   111    -1  -1   2   kg/m2/s  OCPO_emission_flux_from_b
 EmisOCPO_Ship      OCPO   0      10  -1   2   kg/m2/s  OCPO_emission_flux_from_ships
 
 ###############################################################################
-#####  pFe emissions                                                      ##### 
+#####  pFe emissions                                                      #####
 ###############################################################################
 EmispFe_Total      pFe    -1     -1  -1   3   kg/m2/s  pFe_emission_flux_from_all_sectors
 EmispFe_Anthro     pFe    0      1   -1   3   kg/m2/s  pFe_emission_flux_from_anthropogenic
 EmispFe_Ship       pFe    0      10  -1   2   kg/m2/s  pFe_emission_flux_from_ships
 
 ###############################################################################
-#####  POG1 and POG2 emissions                                            ##### 
+#####  POG1 and POG2 emissions                                            #####
 ###############################################################################
 EmisPOG1_Total     POG1   -1     -1  -1   3   kg/m2/s  POG1_emission_flux_from_all_sectors
 EmisPOG1_Anthro    POG1   0      1   -1   3   kg/m2/s  POG1_emission_flux_from_anthropogenic
@@ -364,7 +364,7 @@ EmisPOG2_Anthro    POG2   0      1   -1   3   kg/m2/s  POG2_emission_flux_from_a
 EmisPOG2_BioBurn   POG2   111    -1  -1   2   kg/m2/s  POG2_emission_flux_from_GFED_inventory
 
 ###############################################################################
-#####  PRPE emissions                                                     ##### 
+#####  PRPE emissions                                                     #####
 ###############################################################################
 EmisPRPE_Total     PRPE   -1     -1  -1   3   kg/m2/s  PRPE_emission_flux_from_all_sectors
 EmisPRPE_Aircraft  PRPE   0      20  -1   3   kg/m2/s  PRPE_emission_flux_from_aircraft
@@ -374,7 +374,7 @@ EmisPRPE_Biogenic  PRPE   0      4   -1   2   kg/m2/s  PRPE_emission_flux_from_b
 EmisPRPE_Ship      PRPE   0      10  -1   2   kg/m2/s  PRPE_emission_flux_from_ships
 
 ###############################################################################
-#####  RCHO emissions                                                     ##### 
+#####  RCHO emissions                                                     #####
 ###############################################################################
 EmisRCHO_Total     RCHO   -1     -1  -1   3   kg/m2/s  RCHO_emission_flux_from_all_sectors
 EmisRCHO_Aircraft  RCHO   0      20  -1   3   kg/m2/s  RCHO_emission_flux_from_aircraft
@@ -386,7 +386,7 @@ EmisRCHO_Anthro    RCHO   0      1   -1   3   kg/m2/s  RCHO_emission_flux_from_a
 EmisSESQ_Biogenic  SESQ   0      4   -1   2   kg/m2/s  SESQ_emission_flux_from_biogenic_sources
 
 ###############################################################################
-#####  Sea salt emissions                                                 ##### 
+#####  Sea salt emissions                                                 #####
 ###############################################################################
 EmisBr2_Natural    Br2    0      3   -1   2   kg/m2/s  Br2_emission_flux_from_natural_sources
 EmisBrSALA_Natural BrSALA 0      3   -1   2   kg/m2/s  BrSALA_emission_flux_from_natural_sources
@@ -395,7 +395,7 @@ EmisSALA_Natural   SALA   0      3   -1   2   kg/m2/s  SALA_emission_flux_from_n
 EmisSALC_Natural   SALC   0      3   -1   2   kg/m2/s  SALC_emission_flux_from_natural_sources
 
 ###############################################################################
-#####  SO2 emissions                                                      ##### 
+#####  SO2 emissions                                                      #####
 ###############################################################################
 EmisSO2_Total      SO2    -1     -1  -1   3   kg/m2/s  SO2_emission_flux_from_all_sectors
 EmisSO2_Aircraft   SO2    0      20  -1   3   kg/m2/s  SO2_emission_flux_from_aircraft
@@ -406,7 +406,7 @@ EmisSO2_VolcDegas  SO2    117    52  -1   3   kg/m2/s  SO2_emission_flux_from_no
 EmisSO2_Ship       SO2    0      10  -1   2   kg/m2/s  SO2_emission_flux_from_ships
 
 ###############################################################################
-#####  SO4 emissions                                                      ##### 
+#####  SO4 emissions                                                      #####
 ###############################################################################
 EmisSO4_Total      SO4    -1     -1  -1   3   kg/m2/s  SO4_emission_flux_from_all_sectors
 EmisSO4_Aircraft   SO4    0      20  -1   3   kg/m2/s  SO4_emission_flux_from_aircraft
@@ -414,7 +414,7 @@ EmisSO4_Anthro     SO4    0      1   -1   3   kg/m2/s  SO4_emission_flux_from_an
 EmisSO4_Ship       SO4    0      10  -1   2   kg/m2/s  SO4_emission_flux_from_ship
 
 ###############################################################################
-#####  SOAP sources                                                       ##### 
+#####  SOAP sources                                                       #####
 ###############################################################################
 EmisSOAP_Total     SOAP   -1     -1  -1   3   kg/m2/s  SOAP_emission_flux_from_all_sectors
 EmisSOAP_Aircraft  SOAP   0      20  -1   3   kg/m2/s  SOAP_emission_flux_from_aircraft
@@ -424,7 +424,7 @@ EmisSOAP_BioBurn   SOAP   111    -1  -1   2   kg/m2/s  SOAP_emission_flux_from_b
 EmisSOAP_Ship      SOAP   0      10  -1   2   kg/m2/s  SOAP_emission_flux_from_ships
 
 ###############################################################################
-#####  SOAS sources                                                       ##### 
+#####  SOAS sources                                                       #####
 ###############################################################################
 EmisSOAS_Biogenic  SOAS   0      4   -1   2   kg/m2/s  SOAS_emission_flux_from_biogenic_sources
 
@@ -437,7 +437,7 @@ EmisTOLU_BioBurn   TOLU   111    -1  -1   2   kg/m2/s  TOLU_emission_flux_from_b
 EmisTOLU_Ship      TOLU   0      10  -1   2   kg/m2/s  TOLU_emission_flux_from_ships
 
 ###############################################################################
-#####  XYLE emissions                                                     ##### 
+#####  XYLE emissions                                                     #####
 ###############################################################################
 EmisXYLE_Total     XYLE   -1     -1  -1   3   kg/m2/s  XYLE_emission_flux_from_all_sectors
 EmisXYLE_Anthro    XYLE   0      1   -1   3   kg/m2/s  XYLE_emission_flux_from_anthropogenic
@@ -445,7 +445,7 @@ EmisXYLE_BioBurn   XYLE   111    -1  -1   2   kg/m2/s  XYLE_emission_flux_from_b
 EmisXYLE_Ship      XYLE   0      10  -1   2   kg/m2/s  XYLE_emission_flux_from_ships
 
 ###############################################################################
-#####  INVENTORY DIAGNOSTICS, needed for benchmarking simulations only    ##### 
+#####  INVENTORY DIAGNOSTICS, needed for benchmarking simulations only    #####
 #####  Listed in same order as HEMCO_Config.rc                            #####
 #####  (You can comment these out for production runs, to save memory)    #####
 ###############################################################################
@@ -673,7 +673,7 @@ InvAEIC_SOAP         SOAP   0    20  1   3   kg/m2/s  SOAP_emission_flux_from_AE
 
 #=============================
 # Decaying plants
-#============================= 
+#=============================
 InvPLANTDECAY_ALD2   ALD2   0    3   1   2   kg/m2/s  ALD2_emission_flux_from_PLANTDECAY_inventory
 InvPLANTDECAY_EOH    EOH    0    3   1   2   kg/m2/s  EOH_emission_flux_from_PLANTDECAY_inventory
 

--- a/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.non-benchmark
+++ b/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.non-benchmark
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------------
 #BOP
 #
-# !MODULE: HEMCO_Diagn.rc 
+# !MODULE: HEMCO_Diagn.rc
 #
 # !DESCRIPTION: Configuration file for netCDF diagnostic output from HEMCO.
 #\\
@@ -15,7 +15,7 @@
 #  For a list of species by inventory, please see:
 #  http://wiki.geos-chem.org/HEMCO_data_directories#Default_GEOS-Chem_emissions_configurations
 #
-#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary, 
+#  All diagnostics will now be saved out in units of kg/m2/s.  If necessary,
 #  you can convert hydrocarbon species to e.g. kg C/m2/s in post-processing.
 #
 #  The INVENTORY DIAGNOSTICS (starting with "Inv")  are only needed for
@@ -51,7 +51,7 @@ EmisALD2_PlantDecay ALD2  0      3   -1   2   kg/m2/s  ALD2_emission_flux_from_d
 EmisALD2_Ship      ALD2   0      10  -1   2   kg/m2/s  ALD2_emission_flux_from_ships
 
 ###############################################################################
-#####  ALK4 emissions                                                     ##### 
+#####  ALK4 emissions                                                     #####
 ###############################################################################
 EmisALK4_Total     ALK4   -1     -1  -1   3   kg/m2/s  ALK4_emission_flux_from_all_sectors
 EmisALK4_Aircraft  ALK4   0      20  -1   3   kg/m2/s  ALK4_emission_flux_from_aircraft
@@ -60,7 +60,7 @@ EmisALK4_BioBurn   ALK4   111    -1  -1   2   kg/m2/s  ALK4_emission_flux_from_b
 EmisALK4_Ship      ALK4   0      10  -1   2   kg/m2/s  ALK4_emission_flux_from_ships
 
 ###############################################################################
-#####  BCPI and BCPO emissions                                            ##### 
+#####  BCPI and BCPO emissions                                            #####
 ###############################################################################
 EmisBCPI_Total     BCPI   -1     -1  -1   3   kg/m2/s  BCPI_emission_flux_from_all_sectors
 EmisBCPI_Aircraft  BCPI   0      20  -1   3   kg/m2/s  BCPI_emission_flux_from_aircraft
@@ -73,7 +73,7 @@ EmisBCPO_BioBurn   BCPO   111    -1  -1   2   kg/m2/s  BCPO_emission_flux_from_b
 EmisBCPO_Ship      BCPO   0      10  -1   2   kg/m2/s  BCPO_emission_flux_from_ships
 
 ###############################################################################
-#####  BENZ emissions                                                     ##### 
+#####  BENZ emissions                                                     #####
 ###############################################################################
 EmisBENZ_Total     BENZ   -1     -1  -1   3   kg/m2/s  BENZ_emission_flux_from_all_sectors
 EmisBENZ_Anthro    BENZ   0      1   -1   3   kg/m2/s  BENZ_emission_flux_from_anthropogenic
@@ -105,7 +105,7 @@ EmisC2H6_BioBurn   C2H6   111    -1  -1   2   kg/m2/s  C2H6_emission_flux_from_b
 EmisC2H6_Ship      C2H6   0      10  -1   2   kg/m2/s  C2H6_emission_flux_from_ships
 
 ###############################################################################
-#####  C3H8 emissions                                                     ##### 
+#####  C3H8 emissions                                                     #####
 ###############################################################################
 EmisC3H8_Total     C3H8   -1     -1  -1   3   kg/m2/s  C3H8_emission_flux_from_all_sectors
 EmisC3H8_Aircraft  C3H8   0      20  -1   3   kg/m2/s  C3H8_emission_flux_from_aircraft
@@ -114,27 +114,27 @@ EmisC3H8_BioBurn   C3H8   111    -1  -1   2   kg/m2/s  C3H8_emission_flux_from_b
 EmisC3H8_Ship      C3H8   0      10  -1   2   kg/m2/s  C3H8_emission_flux_from_ships
 
 ###############################################################################
-#####  CH2Br2 emissions                                                   ##### 
+#####  CH2Br2 emissions                                                   #####
 ###############################################################################
 EmisCH2Br2_Ocean   CH2Br2 0      1   -1   2   kg/m2/s  CH2Br2_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2I2 emissions                                                   ##### 
+#####  CH2I2 emissions                                                   #####
 ###############################################################################
 EmisCH2I2_Ocean    CH2I2  0     1    -1   2   kg/m2/s  CH2I2_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2ICl emissions                                                   ##### 
+#####  CH2ICl emissions                                                   #####
 ###############################################################################
 EmisCH2ICl_Ocean   CH2ICl 0     1    -1   2   kg/m2/s  CH2ICl_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2IBr emissions                                                   ##### 
+#####  CH2IBr emissions                                                   #####
 ###############################################################################
 EmisCH2IBr_Ocean   CH2IBr 0     1    -1   2   kg/m2/s  CH2IBr_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH2O emissions                                                     ##### 
+#####  CH2O emissions                                                     #####
 ###############################################################################
 EmisCH2O_Total     CH2O   -1     -1  -1   3   kg/m2/s  CH2O_emission_flux_from_all_sectors
 EmisCH2O_Aircraft  CH2O   0      20  -1   3   kg/m2/s  CH2O_emission_flux_from_aircraft
@@ -143,12 +143,12 @@ EmisCH2O_BioBurn   CH2O   111    -1  -1   2   kg/m2/s  CH2O_emission_flux_from_b
 EmisCH2O_Ship      CH2O   0      10  -1   2   kg/m2/s  CH2O_emission_flux_from_ships
 
 ###############################################################################
-#####  CH3I emissions                                                   ##### 
+#####  CH3I emissions                                                   #####
 ###############################################################################
 EmisCH3I_Ocean     CH3I   0     1    -1   2   kg/m2/s  CH3I_emission_flux_from_ocean
 
 ###############################################################################
-#####  CH4 emissions                                                      ##### 
+#####  CH4 emissions                                                      #####
 ###############################################################################
 EmisCH4_Total      CH4    -1     -1  -1   3   kg/m2/s  CH4_emission_flux_from_all_sectors
 EmisCH4_Anthro     CH4    0      1   -1   3   kg/m2/s  CH4_emission_flux_from_anthropogenic
@@ -156,12 +156,12 @@ EmisCH4_BioBurn    CH4    0      5   -1   2   kg/m2/s  CH4_emission_flux_from_bi
 EmisCH4_Ship       CH4    0      10  -1   2   kg/m2/s  CH4_emission_flux_from_ships
 
 ###############################################################################
-#####  CHBr3 emissions                                                    ##### 
+#####  CHBr3 emissions                                                    #####
 ###############################################################################
 EmisCHBr3_Ocean    CHBr3  0      1   -1   2   kg/m2/s  CHBr3_emission_flux_from_ocean
 
 ###############################################################################
-#####  CO sources                                                         ##### 
+#####  CO sources                                                         #####
 ###############################################################################
 EmisCO_Total       CO     -1     -1  -1   3   kg/m2/s  CO_emission_flux_from_all_sectors
 EmisCO_Aircraft    CO     0      20  -1   3   kg/m2/s  CO_emission_flux_from_aircraft
@@ -170,7 +170,7 @@ EmisCO_BioBurn     CO     111    -1  -1   2   kg/m2/s  CO_emission_flux_from_bio
 EmisCO_Ship        CO     0      10  -1   2   kg/m2/s  CO_emission_flux_from_ships
 
 ###############################################################################
-#####  CO2 emissions                                                      ##### 
+#####  CO2 emissions                                                      #####
 ###############################################################################
 EmisCO2_Total      CO2    -1     -1  -1   3   kg/m2/s  CO2_emission_flux_from_all_sectors
 EmisCO2_Anthro     CO2    0      1   -1   3   kg/m2/s  CO2_emission_flux_from_anthropogenic
@@ -178,12 +178,12 @@ EmisCO2_BioBurn    CO2    0      5   -1   2   kg/m2/s  CO2_emission_flux_from_bi
 EmisCO2_Ship       CO2    0      10  -1   2   kg/m2/s  CO2_emission_flux_from_ships
 
 ###############################################################################
-#####  DMS emissions                                                      ##### 
+#####  DMS emissions                                                      #####
 ###############################################################################
 EmisDMS_Ocean      DMS    101    -1  -1   2   kg/m2/s  DMS_emission_flux_from_ocean
 
 ###############################################################################
-#####  Dust emissions                                                     ##### 
+#####  Dust emissions                                                     #####
 ###############################################################################
 EmisDST1_Total     DST1   -1     -1  -1   2   kg/m2/s  DST1_emission_flux_from_all_sectors
 EmisDST1_Anthro    DST1   0      1   -1   2   kg/m2/s  DST1_emission_flux_from_anthropogenic
@@ -193,7 +193,7 @@ EmisDST3_Natural   DST3   0      3   -1   2   kg/m2/s  DST3_emission_flux_from_n
 EmisDST4_Natural   DST4   0      3   -1   2   kg/m2/s  DST4_emission_flux_from_natural_sources
 
 ###############################################################################
-#####  EOH emissions                                                      ##### 
+#####  EOH emissions                                                      #####
 ###############################################################################
 EmisEOH_Total      EOH    -1     -1  -1   3   kg/m2/s  EOH_emission_flux_from_all_sectors
 EmisEOH_Anthro     EOH    0      1   -1   3   kg/m2/s  EOH_emission_flux_from_anthropogenic
@@ -203,25 +203,25 @@ EmisEOH_PlantDecay EOH    0      3   -1   2   kg/m2/s  EOH_emission_flux_from_de
 EmisEOH_Ship       EOH    0      10  -1   2   kg/m2/s  EOH_emission_flux_from_ships
 
 ###############################################################################
-#####  HAC emissions                                                     ##### 
+#####  HAC emissions                                                     #####
 ###############################################################################
 EmisHAC_Total      HAC    -1     -1  -1   3   kg/m2/s  HAC_emission_flux_from_all_sectors
 EmisHAC_Anthro     HAC    0      1   -1   3   kg/m2/s  HAC_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  GLYC emissions                                                     ##### 
+#####  GLYC emissions                                                     #####
 ###############################################################################
 EmisGLYC_Total     GLYC   -1     -1  -1   3   kg/m2/s  GLYC_emission_flux_from_all_sectors
 EmisGLYC_Anthro    GLYC   0      1   -1   3   kg/m2/s  GLYC_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  GLYX emissions                                                     ##### 
+#####  GLYX emissions                                                     #####
 ###############################################################################
 EmisGLYX_Total     GLYX   -1     -1  -1   3   kg/m2/s  GLYX_emission_flux_from_all_sectors
 EmisGLYX_Anthro    GLYX   0      1   -1   3   kg/m2/s  GLYX_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  HCOOH sources                                                      ##### 
+#####  HCOOH sources                                                      #####
 ###############################################################################
 EmisHCOOH_Total    HCOOH  -1     -1  -1   3   kg/m2/s  HCOOH_emission_flux_from_all_sectors
 EmisHCOOH_Anthro   HCOOH  0      1   -1   3   kg/m2/s  HCOOH_emission_flux_from_anthropogenic
@@ -250,7 +250,7 @@ EmisISOP_Biogenic  ISOP   0      4   -1   2   kg/m2/s  ISOP_emission_flux_from_b
 EmisLIMO_Biogenic  LIMO   0      4   -1   2   kg/m2/s  LIMO_emission_flux_from_biogenic_sources
 
 ###############################################################################
-#####  MACR emissions                                                     ##### 
+#####  MACR emissions                                                     #####
 ###############################################################################
 EmisMACR_Total     MACR   -1     -1  -1   3   kg/m2/s  MACR_emission_flux_from_all_sectors
 EmisMACR_Aircraft  MACR   0      20  -1   3   kg/m2/s  MACR_emission_flux_from_anthropogenic
@@ -265,7 +265,7 @@ EmisMEK_BioBurn    MEK    111    -1  -1   2   kg/m2/s  MEK_emission_flux_from_bi
 EmisMEK_Ship       MEK    0      10  -1   2   kg/m2/s  MEK_emission_flux_from_ships
 
 ###############################################################################
-#####  MGLY emissions                                                     ##### 
+#####  MGLY emissions                                                     #####
 ###############################################################################
 EmisMGLY_Total     MGLY   -1     -1  -1   3   kg/m2/s  MGLY_emission_flux_from_all_sectors
 EmisMGLY_Anthro    MGLY   0      1   -1   3   kg/m2/s  MGLY_emission_flux_from_anthropogenic
@@ -295,7 +295,7 @@ EmisMTPO_Biogenic  MTPO   0      4   -1   2   kg/m2/s  MTPO_emission_flux_from_b
 EmisMVK_Anthro     MVK    0      1   -1   3   kg/m2/s  MVK_emission_flux_from_anthropogenic
 
 ###############################################################################
-#####  NAP emissions                                                      ##### 
+#####  NAP emissions                                                      #####
 ###############################################################################
 EmisNAP_Total      NAP    -1     -1  -1   3   kg/m2/s  NAP_emission_flux_from_all_sectors
 EmisNAP_Anthro     NAP    0      1   -1   3   kg/m2/s  NAP_emission_flux_from_anthropogenic
@@ -323,18 +323,18 @@ EmisNO_Ship        NO     102    -1  -1   2   kg/m2/s  NO_emission_flux_from_shi
 EmisNO_Soil        NO     0      3   -1   2   kg/m2/s  NO_emission_flux_from_soil
 
 ###############################################################################
-#####  NO2 emissions                                                      ##### 
+#####  NO2 emissions                                                      #####
 ###############################################################################
 EmisNO2_Anthro     NO2    0      1   -1   3   kg/m2/s  NO2_emission_flux_from_anthropogenic
 EmisNO2_Ship       NO2    102    -1  -1   2   kg/m2/s  NO2_emission_flux_from_ships
 
 ###############################################################################
-#####  O3 emissions                                                       ##### 
+#####  O3 emissions                                                       #####
 ###############################################################################
 EmisO3_Ship        O3     102    -1  -1   2   kg/m2/s  O3_emission_flux_from_ships
 
 ###############################################################################
-#####  OCPI and OCPO emissions                                            ##### 
+#####  OCPI and OCPO emissions                                            #####
 ###############################################################################
 EmisOCPI_Total     OCPI   -1     -1  -1   3   kg/m2/s  OCPI_emission_flux_from_all_sectors
 EmisOCPI_Aircraft  OCPI   0      20  -1   3   kg/m2/s  OCPI_emission_flux_from_aircraft
@@ -347,14 +347,14 @@ EmisOCPO_BioBurn   OCPO   111    -1  -1   2   kg/m2/s  OCPO_emission_flux_from_b
 EmisOCPO_Ship      OCPO   0      10  -1   2   kg/m2/s  OCPO_emission_flux_from_ships
 
 ###############################################################################
-#####  pFe emissions                                                      ##### 
+#####  pFe emissions                                                      #####
 ###############################################################################
 EmispFe_Total      pFe    -1     -1  -1   3   kg/m2/s  pFe_emission_flux_from_all_sectors
 EmispFe_Anthro     pFe    0      1   -1   3   kg/m2/s  pFe_emission_flux_from_anthropogenic
 EmispFe_Ship       pFe    0      10  -1   2   kg/m2/s  pFe_emission_flux_from_ships
 
 ###############################################################################
-#####  POG1 and POG2 emissions                                            ##### 
+#####  POG1 and POG2 emissions                                            #####
 ###############################################################################
 EmisPOG1_Total     POG1   -1     -1  -1   3   kg/m2/s  POG1_emission_flux_from_all_sectors
 EmisPOG1_Anthro    POG1   0      1   -1   3   kg/m2/s  POG1_emission_flux_from_anthropogenic
@@ -364,7 +364,7 @@ EmisPOG2_Anthro    POG2   0      1   -1   3   kg/m2/s  POG2_emission_flux_from_a
 EmisPOG2_BioBurn   POG2   111    -1  -1   2   kg/m2/s  POG2_emission_flux_from_GFED_inventory
 
 ###############################################################################
-#####  PRPE emissions                                                     ##### 
+#####  PRPE emissions                                                     #####
 ###############################################################################
 EmisPRPE_Total     PRPE   -1     -1  -1   3   kg/m2/s  PRPE_emission_flux_from_all_sectors
 EmisPRPE_Aircraft  PRPE   0      20  -1   3   kg/m2/s  PRPE_emission_flux_from_aircraft
@@ -374,7 +374,7 @@ EmisPRPE_Biogenic  PRPE   0      4   -1   2   kg/m2/s  PRPE_emission_flux_from_b
 EmisPRPE_Ship      PRPE   0      10  -1   2   kg/m2/s  PRPE_emission_flux_from_ships
 
 ###############################################################################
-#####  RCHO emissions                                                     ##### 
+#####  RCHO emissions                                                     #####
 ###############################################################################
 EmisRCHO_Total     RCHO   -1     -1  -1   3   kg/m2/s  RCHO_emission_flux_from_all_sectors
 EmisRCHO_Aircraft  RCHO   0      20  -1   3   kg/m2/s  RCHO_emission_flux_from_aircraft
@@ -386,7 +386,7 @@ EmisRCHO_Anthro    RCHO   0      1   -1   3   kg/m2/s  RCHO_emission_flux_from_a
 EmisSESQ_Biogenic  SESQ   0      4   -1   2   kg/m2/s  SESQ_emission_flux_from_biogenic_sources
 
 ###############################################################################
-#####  Sea salt emissions                                                 ##### 
+#####  Sea salt emissions                                                 #####
 ###############################################################################
 EmisBr2_Natural    Br2    0      3   -1   2   kg/m2/s  Br2_emission_flux_from_natural_sources
 EmisBrSALA_Natural BrSALA 0      3   -1   2   kg/m2/s  BrSALA_emission_flux_from_natural_sources
@@ -395,7 +395,7 @@ EmisSALA_Natural   SALA   0      3   -1   2   kg/m2/s  SALA_emission_flux_from_n
 EmisSALC_Natural   SALC   0      3   -1   2   kg/m2/s  SALC_emission_flux_from_natural_sources
 
 ###############################################################################
-#####  SO2 emissions                                                      ##### 
+#####  SO2 emissions                                                      #####
 ###############################################################################
 EmisSO2_Total      SO2    -1     -1  -1   3   kg/m2/s  SO2_emission_flux_from_all_sectors
 EmisSO2_Aircraft   SO2    0      20  -1   3   kg/m2/s  SO2_emission_flux_from_aircraft
@@ -406,7 +406,7 @@ EmisSO2_VolcDegas  SO2    117    52  -1   3   kg/m2/s  SO2_emission_flux_from_no
 EmisSO2_Ship       SO2    0      10  -1   2   kg/m2/s  SO2_emission_flux_from_ships
 
 ###############################################################################
-#####  SO4 emissions                                                      ##### 
+#####  SO4 emissions                                                      #####
 ###############################################################################
 EmisSO4_Total      SO4    -1     -1  -1   3   kg/m2/s  SO4_emission_flux_from_all_sectors
 EmisSO4_Aircraft   SO4    0      20  -1   3   kg/m2/s  SO4_emission_flux_from_aircraft
@@ -414,7 +414,7 @@ EmisSO4_Anthro     SO4    0      1   -1   3   kg/m2/s  SO4_emission_flux_from_an
 EmisSO4_Ship       SO4    0      10  -1   2   kg/m2/s  SO4_emission_flux_from_ship
 
 ###############################################################################
-#####  SOAP sources                                                       ##### 
+#####  SOAP sources                                                       #####
 ###############################################################################
 EmisSOAP_Total     SOAP   -1     -1  -1   3   kg/m2/s  SOAP_emission_flux_from_all_sectors
 EmisSOAP_Aircraft  SOAP   0      20  -1   3   kg/m2/s  SOAP_emission_flux_from_aircraft
@@ -424,7 +424,7 @@ EmisSOAP_BioBurn   SOAP   111    -1  -1   2   kg/m2/s  SOAP_emission_flux_from_b
 EmisSOAP_Ship      SOAP   0      10  -1   2   kg/m2/s  SOAP_emission_flux_from_ships
 
 ###############################################################################
-#####  SOAS sources                                                       ##### 
+#####  SOAS sources                                                       #####
 ###############################################################################
 EmisSOAS_Biogenic  SOAS   0      4   -1   2   kg/m2/s  SOAS_emission_flux_from_biogenic_sources
 
@@ -437,7 +437,7 @@ EmisTOLU_BioBurn   TOLU   111    -1  -1   2   kg/m2/s  TOLU_emission_flux_from_b
 EmisTOLU_Ship      TOLU   0      10  -1   2   kg/m2/s  TOLU_emission_flux_from_ships
 
 ###############################################################################
-#####  XYLE emissions                                                     ##### 
+#####  XYLE emissions                                                     #####
 ###############################################################################
 EmisXYLE_Total     XYLE   -1     -1  -1   3   kg/m2/s  XYLE_emission_flux_from_all_sectors
 EmisXYLE_Anthro    XYLE   0      1   -1   3   kg/m2/s  XYLE_emission_flux_from_anthropogenic

--- a/runs/shared_inputs/tagCO/HEMCO_Config.template
+++ b/runs/shared_inputs/tagCO/HEMCO_Config.template
@@ -6,13 +6,13 @@
 # !MODULE: HEMCO_Config.template.tagCO
 #
 # !DESCRIPTION: Template file used to create the HEMCO_Config.rc file
-#  for the tagged CO ("tagCO") simulation. 
+#  for the tagged CO ("tagCO") simulation.
 #\\
 #\\
 # !REMARKS:
 #  The following tokens will be replaced:
 #  (1) ROOT    : Filepath to HEMCO root directory
-#  (2) CFDIR   : Filepath to directory of this configuration file. 
+#  (2) CFDIR   : Filepath to directory of this configuration file.
 #  (3) MET     : Met field type (from G-C compilation command)
 #  (4) GRID    : Horizontal grid type (from G-C compilation command)
 #  (5) SIM     : Simulation type (from G-C compilation command)
@@ -22,13 +22,12 @@
 #  (8) LEVFULL : String w/ the # of levels in the full GEOS-Chem grid
 #                as used in some filenames (e.g. "55L", "72L")
 #
-# !REVISION HISTORY: 
+# !REVISION HISTORY:
 #  Navigate to your unit tester directory and type 'gitk' at the prompt
 #  to browse the revision history.
 #EOP
 #------------------------------------------------------------------------------
 #BOC
-
 ###############################################################################
 ### BEGIN SECTION SETTINGS
 ###############################################################################
@@ -53,8 +52,8 @@ Mask fractions:              false
 ### BEGIN SECTION EXTENSION SWITCHES
 ###############################################################################
 #
-# ExtNr ExtName                 on/off  Species 
-0       Base                    : on    *             
+# ExtNr ExtName                 on/off  Species
+0       Base                    : on    *
 # ----- RESTART FIELDS ----------------------
     --> GC_RESTART              :       true
     --> HEMCO_RESTART           :       true
@@ -63,7 +62,7 @@ Mask fractions:              false
     --> NEI2011_HOURLY         :       false
     --> NEI2011_MONMEAN        :       true
     --> MIX                    :       true
-    --> DICE_Africa            :       true 
+    --> DICE_Africa            :       true
 # ----- GLOBAL INVENTORIES ------------------
     --> CEDS                   :       true
     --> EDGARv43               :       false
@@ -80,7 +79,7 @@ Mask fractions:              false
     --> AEIC                   :       true
     --> DECAYING_PLANTS        :       true
 # ----- FUTURE EMISSIONS --------------------
-    --> RCP_3PD                :       false 
+    --> RCP_3PD                :       false
     --> RCP_45                 :       false
     --> RCP_60                 :       false
     --> RCP_85                 :       false
@@ -97,7 +96,7 @@ Mask fractions:              false
     --> Yuan_XLAI              :       false
 # -----------------------------------------------------------------------------
 108     MEGAN                  : on    ISOP/ACET
-    --> Isoprene scaling       :       1.0 
+    --> Isoprene scaling       :       1.0
     --> CO2 inhibition         :       true
     --> CO2 conc (ppmv)        :       390.0
 109     MEGAN_Mono             : on    MTPA/LIMO/MTPO
@@ -105,7 +104,7 @@ Mask fractions:              false
 ### END SECTION EXTENSION SWITCHES ###
 
 ###############################################################################
-### BEGIN SECTION BASE EMISSIONS 
+### BEGIN SECTION BASE EMISSIONS
 ###############################################################################
 
 # ExtNr	Name sourceFile	sourceVar sourceTime C/R/E SrcDim SrcUnit Species ScalIDs Cat Hier
@@ -235,27 +234,27 @@ Mask fractions:              false
 #==============================================================================
 # --- DICE-Africa emission inventory (Marais and Wiedinmyer, ES&T, 2016) ---
 #
-# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse 
-# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making 
-# and use, backup generators, agricultural waste burning for cooking, gas 
+# DICE-Africa includes regional (Africa) emissions of biofuel and diffuse
+# anthropogenic emissions from cars and motorcycles, biofuels, charcoal making
+# and use, backup generators, agricultural waste burning for cooking, gas
 # flares, and ad-hoc/informal oil refining.
 #
-# Other pollution sources (formal industry, power generation using fossil 
-# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC. 
+# Other pollution sources (formal industry, power generation using fossil
+# fuels) are from the EDGAR v4.3 inventory for CO, SO2, NH3, NOx BC, and OC.
 #
-# NMVOCs from sources not accounted for in DICE-Africa aren't included here, 
-# as these emissions are likely to be low compared to the DICE pollution 
-# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish 
+# NMVOCs from sources not accounted for in DICE-Africa aren't included here,
+# as these emissions are likely to be low compared to the DICE pollution
+# sources and RETRO v1 as implemented in GEOS-Chem doesn't distinguish
 # emissions by sector/activity.
 #
-# Emissions for 2013 are defined below, but DICE-Africa also includes 
-# emissions for 2006.  Developers recommend using population change to 
-# estimate emissions, if users want to use annual trends in pollutant 
+# Emissions for 2013 are defined below, but DICE-Africa also includes
+# emissions for 2006.  Developers recommend using population change to
+# estimate emissions, if users want to use annual trends in pollutant
 # emissions to estimate in other years.
 #==============================================================================
 (((DICE_Africa
 # ------------------------
-#  Cars 
+#  Cars
 # ------------------------
 0 DICE_CARS_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-cars-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      1 60
 0 DICE_CARS_CO_eur  -                                                                -  -          - -  -       COeur  26/1008/1101 1 60
@@ -263,7 +262,7 @@ Mask fractions:              false
 0 DICE_CARS_CO_oth  -                                                                -  -          - -  -       COoth  26/1008/1103 1 60
 
 # ------------------------
-#  Motorcycles 
+#  Motorcycles
 # ------------------------
 0 DICE_MOTORCYCLES_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-motorcycles-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      1 60
 0 DICE_MOTORCYCLES_CO_eur  -                                                                       -  -          - -  -       COeur  26/1008/1101 1 60
@@ -271,7 +270,7 @@ Mask fractions:              false
 0 DICE_MOTORCYCLES_CO_oth  -                                                                       -  -          - -  -       COoth  26/1008/1103 1 60
 
 # ------------------------
-#  Backup generators 
+#  Backup generators
 # ------------------------
 0 DICE_BACKUPGEN_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-generator-use-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      1 60
 0 DICE_BACKUPGEN_CO_eur  -                                                                         -  -          - -  -       COeur  26/1008/1101 1 60
@@ -279,7 +278,7 @@ Mask fractions:              false
 0 DICE_BACKUPGEN_CO_oth  -                                                                         -  -          - -  -       COoth  26/1008/1103 1 60
 
 # ------------------------
-#  Charcoal production 
+#  Charcoal production
 # ------------------------
 0 DICE_CHARCOALPROD_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-production-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008/320      1 60
 0 DICE_CHARCOALPROD_CO_eur  -                                                                               -  -          - -  -       COeur  26/1008/320/1101 1 60
@@ -287,7 +286,7 @@ Mask fractions:              false
 0 DICE_CHARCOALPROD_CO_oth  -                                                                               -  -          - -  -       COoth  26/1008/320/1103 1 60
 
 # ------------------------
-#  Flaring of natural gas 
+#  Flaring of natural gas
 # ------------------------
 0 DICE_GASFLARE_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-gas-flares-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      1 60
 0 DICE_GASFLARE_CO_eur  -                                                                      -  -          - -  -       COeur  26/1008/1101 1 60
@@ -295,7 +294,7 @@ Mask fractions:              false
 0 DICE_GASFLARE_CO_oth  -                                                                      -  -          - -  -       COoth  26/1008/1103 1 60
 
 # ------------------------------
-#  Ag waste burning for energy 
+#  Ag waste burning for energy
 # ------------------------------
 0 DICE_AGBURNING_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-crop-residue-use-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      2 60
 0 DICE_AGBURNING_CO_eur  -                                                                                      -  -          - -  -       COeur  26/1008/1101 2 60
@@ -303,7 +302,7 @@ Mask fractions:              false
 0 DICE_AGBURNING_CO_oth  -                                                                                      -  -          - -  -       COoth  26/1008/1103 2 60
 
 # ------------------------------
-#  Charcoal use 
+#  Charcoal use
 # ------------------------------
 0 DICE_CHARCOALUSE_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-charcoal-use-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      2 60
 0 DICE_CHARCOALUSE_CO_eur  -                                                                        -  -          - -  -       COeur  26/1008/1101 2 60
@@ -311,7 +310,7 @@ Mask fractions:              false
 0 DICE_CHARCOALUSE_CO_oth  -                                                                        -  -          - -  -       COoth  26/1008/1103 2 60
 
 # ------------------------------
-#  Kerosene use 
+#  Kerosene use
 # ------------------------------
 0 DICE_KEROSENE_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-kerosene-use-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      1 60
 0 DICE_KEROSENE_CO_eur  -                                                                        -  -          - -  -       COeur  26/1008/1101 1 60
@@ -319,7 +318,7 @@ Mask fractions:              false
 0 DICE_KEROSENE_CO_oth  -                                                                        -  -          - -  -       COoth  26/1008/1103 1 60
 
 # ------------------------------
-#  Artisanal oil refining 
+#  Artisanal oil refining
 # ------------------------------
 0 DICE_OILREFINING_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-adhoc-oil-refining-2006-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      1 60
 0 DICE_OILREFINING_CO_eur  -                                                                              -  -          - -  -       COeur  26/1008/1101 1 60
@@ -327,7 +326,7 @@ Mask fractions:              false
 0 DICE_OILREFINING_CO_oth  -                                                                              -  -          - -  -       COoth  26/1008/1103 1 60
 
 # --------------------------
-#  Household fuelwood use 
+#  Household fuelwood use
 # --------------------------
 0 DICE_HOUSEFUELWOOD_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-household-fuelwood-use-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      2 60
 0 DICE_HOUSEFUELWOOD_CO_eur  -                                                                                  -  -          - -  -       COeur  26/1008/1101 2 60
@@ -335,7 +334,7 @@ Mask fractions:              false
 0 DICE_HOUSEFUELWOOD_CO_oth  -                                                                                  -  -          - -  -       COoth  26/1008/1103 2 60
 
 # ---------------------------------
-#  Commercial (other) fuelwood use 
+#  Commercial (other) fuelwood use
 # ---------------------------------
 0 DICE_OTHERFUELWOOD_CO      $ROOT/DICE_Africa/v2016-10/DICE-Africa-other-fuelwood-use-2013-v01-4Oct2016.nc CO 2013/1/1/0 C xy g/m2/yr CO     26/1008      2 60
 0 DICE_OTHERFUELWOOD_CO_eur  -                                                                              -  -          - -  -       COeur  26/1008/1101 2 60
@@ -429,7 +428,7 @@ Mask fractions:              false
 #
 # %%% NOTE: This is an optional inventory. You may select either CEDS, EDGAR,
 #  or HTAP for the global base emissions %%%
-# 
+#
 # The following emissions are not included in EDGAR and will be added:
 #  * Wiedinmyer et al. (2014) global trash emissions
 #
@@ -658,20 +657,20 @@ Mask fractions:              false
 # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 #==============================================================================
 (((QFED2
-0 QFED_CO_PBL      $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO      54/75/311       5 2 
-0 QFED_CObbAm_PBL  -                                                               -       -                     - -             -       CObbam  54/75/311/1104  5 2 
-0 QFED_CObbAf_PBL  -                                                               -       -                     - -             -       CObbaf  54/75/311/1105  5 2 
-0 QFED_CObbAs_PBL  -                                                               -       -                     - -             -       CObbas  54/75/311/1106  5 2 
-0 QFED_CObbOc_PBL  -                                                               -       -                     - -             -       CObboc  54/75/311/1107  5 2 
-0 QFED_CObbEu_PBL  -                                                               -       -                     - -             -       CObbeu  54/75/311/1108  5 2 
-0 QFED_CObbOth_PBL -                                                               -       -                     - -             -       CObboth 54/75/311/1109  5 2 
+0 QFED_CO_PBL      $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=1:PBL     kg/m2/s CO      54/75/311       5 2
+0 QFED_CObbAm_PBL  -                                                               -       -                     - -             -       CObbam  54/75/311/1104  5 2
+0 QFED_CObbAf_PBL  -                                                               -       -                     - -             -       CObbaf  54/75/311/1105  5 2
+0 QFED_CObbAs_PBL  -                                                               -       -                     - -             -       CObbas  54/75/311/1106  5 2
+0 QFED_CObbOc_PBL  -                                                               -       -                     - -             -       CObboc  54/75/311/1107  5 2
+0 QFED_CObbEu_PBL  -                                                               -       -                     - -             -       CObbeu  54/75/311/1108  5 2
+0 QFED_CObbOth_PBL -                                                               -       -                     - -             -       CObboth 54/75/311/1109  5 2
 0 QFED_CO_FT       $ROOT/QFED/v2018-07/$YYYY/$MM/qfed2.emis_co.006.$YYYY$MM$DD.nc4 biomass 2000-2017/1-12/1-31/0 C xyL=PBL:5500m kg/m2/s CO      54/75/312       5 2
-0 QFED_CObbAm_FT   -                                                               -       -                     - -             -       CObbam  54/75/312/1104  5 2 
-0 QFED_CObbAf_FT   -                                                               -       -                     - -             -       CObbaf  54/75/312/1105  5 2 
-0 QFED_CObbAs_FT   -                                                               -       -                     - -             -       CObbas  54/75/312/1106  5 2 
-0 QFED_CObbOc_FT   -                                                               -       -                     - -             -       CObboc  54/75/312/1107  5 2 
-0 QFED_CObbEu_FT   -                                                               -       -                     - -             -       CObbeu  54/75/312/1108  5 2 
-0 QFED_CObbOth_FT  -                                                               -       -                     - -             -       CObboth 54/75/312/1109  5 2 
+0 QFED_CObbAm_FT   -                                                               -       -                     - -             -       CObbam  54/75/312/1104  5 2
+0 QFED_CObbAf_FT   -                                                               -       -                     - -             -       CObbaf  54/75/312/1105  5 2
+0 QFED_CObbAs_FT   -                                                               -       -                     - -             -       CObbas  54/75/312/1106  5 2
+0 QFED_CObbOc_FT   -                                                               -       -                     - -             -       CObboc  54/75/312/1107  5 2
+0 QFED_CObbEu_FT   -                                                               -       -                     - -             -       CObbeu  54/75/312/1108  5 2
+0 QFED_CObbOth_FT  -                                                               -       -                     - -             -       CObboth 54/75/312/1109  5 2
 )))QFED2
 
 #==============================================================================
@@ -690,20 +689,20 @@ Mask fractions:              false
 ###############################################################################
 ### EXTENSION DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### These fields are needed by the extensions listed above. The assigned ExtNr 
-### must match the ExtNr entry in section 'Extension switches'. These fields 
+### These fields are needed by the extensions listed above. The assigned ExtNr
+### must match the ExtNr entry in section 'Extension switches'. These fields
 ### are only read if the extension is enabled.  The fields are imported by the
-### extensions by field name.  The name given here must match the name used 
-### in the extension's source code. 
+### extensions by field name.  The name given here must match the name used
+### in the extension's source code.
 ###############################################################################
 
 #==============================================================================
 # --- MEGAN biogenic emissions (Extension 108)
 #
-# NOTE: These are the base emissions, which will be converted to kgC/m2/s by 
-# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit 
-# conversion. Since netCDF files are already in mass carbon (ug(C)), the only 
-# important thing is to specify a VOC with a specified MW of 12g/mol. 
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by
+# HEMCO. The specified species (OCPI/ISOP/ACET) are required for proper unit
+# conversion. Since netCDF files are already in mass carbon (ug(C)), the only
+# important thing is to specify a VOC with a specified MW of 12g/mol.
 # This is the case for OCPI, ISOP and ACET.
 #
 # We don't need to read EF maps for acetone, a-pinene or myrcene. We now
@@ -746,10 +745,10 @@ Mask fractions:              false
 ###############################################################################
 ### NON-EMISSIONS DATA (subsection of BASE EMISSIONS SECTION)
 ###
-### Non-emissions data. The following fields are read through HEMCO but do 
-### not contain emissions data. The extension number is set to wildcard 
-### character denoting that these fields will not be considered for emission 
-### calculation. A given entry is only read if the assigned species name is 
+### Non-emissions data. The following fields are read through HEMCO but do
+### not contain emissions data. The extension number is set to wildcard
+### character denoting that these fields will not be considered for emission
+### calculation. A given entry is only read if the assigned species name is
 ### an HEMCO species.
 ###############################################################################
 
@@ -888,7 +887,7 @@ Mask fractions:              false
 #==============================================================================
 # --- NOAA GMD monthly mean surface CH4 ---
 #==============================================================================
-* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
+* NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1
 
 #==============================================================================
 # --- Olson land map masks ---
@@ -1153,7 +1152,7 @@ Mask fractions:              false
 ### END SECTION BASE EMISSIONS ###
 
 ###############################################################################
-### BEGIN SECTION SCALE FACTORS 
+### BEGIN SECTION SCALE FACTORS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper
@@ -1190,7 +1189,7 @@ Mask fractions:              false
 24 TOTFUEL_2008      $ROOT/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc NOxscalar 2008/1/1/0      C xy 1 -1
 
 #==============================================================================
-# --- diurnal scale factors --- 
+# --- diurnal scale factors ---
 #==============================================================================
 26 GEIA_TOD_FOSSIL 0.45/0.45/0.6/0.6/0.6/0.6/1.45/1.45/1.45/1.45/1.4/1.4/1.4/1.4/1.45/1.45/1.45/1.45/0.65/0.65/0.65/0.65/0.45/0.45 - - - xy 1 1
 
@@ -1199,9 +1198,9 @@ Mask fractions:              false
 #==============================================================================
 
 # for EDGAR 4.3.1:
-# Using data of 2010, the calculated seasonal ratio for different species in the 
+# Using data of 2010, the calculated seasonal ratio for different species in the
 # same sector are nearly identical, possibly due to consistent activity data used.
-# Therefore we use the seasonal scale factors of CO in 2010 for most sectors, 
+# Therefore we use the seasonal scale factors of CO in 2010 for most sectors,
 # except for AGR, AWB and SOL.
 # For AGR, the NH3 AGR seasonal scale factors are used.
 # For AWB, the CO AGR seasonal scale factors are used.
@@ -1222,9 +1221,9 @@ Mask fractions:              false
 #==============================================================================
 # --- VOC speciations ---
 #
-# CO sources are scaled to account for co-emitted VOCs. Fossil fuel and 
-# emissions are scaled by 19% and biomass burning emissions are scaled by 
-# 11%. More information is given in Duncan et al, JGR, 112, D22301 (2007). 
+# CO sources are scaled to account for co-emitted VOCs. Fossil fuel and
+# emissions are scaled by 19% and biomass burning emissions are scaled by
+# 11%. More information is given in Duncan et al, JGR, 112, D22301 (2007).
 #==============================================================================
 52 COPROD_FOSSIL   1.19  - - - xy 1 1
 54 COPROD_BIOMASS  1.11  - - - xy 1 1
@@ -1247,17 +1246,17 @@ Mask fractions:              false
 #==============================================================================
 # --- AEIC aircraft emissions ---
 #
-# Sulfur conversion factors are calculated as 
+# Sulfur conversion factors are calculated as
 #     so4 = 3 * a * b and so2 = 2 * a * (1-b)
 #
-# where 
-#     a = fraction by mass (6.0e-4) and 
+# where
+#     a = fraction by mass (6.0e-4) and
 #     b = conversion efficiency (2.0e-2).
 #
 # The factors 2 and 3 come from sulfur mass conversions (96/32 and 64/32).
 # All factors are taken from AEIC_mod.F, following Seb Estham's appraoch.
-# Note that all emissions become multiplied by a factor of 1e-3 (except for 
-# the fuelburn emissions) in the original AEIC code. I'm not sure if this 
+# Note that all emissions become multiplied by a factor of 1e-3 (except for
+# the fuelburn emissions) in the original AEIC code. I'm not sure if this
 # is because the netCDF data is in g instead of kg?
 #==============================================================================
 110 AEICNOCO 1.000000e-3 - -  - xy 1 1
@@ -1270,7 +1269,7 @@ Mask fractions:              false
 #==============================================================================
 # --- NEI 20011 scale factors ---
 #==============================================================================
-252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1 
+252 NEI11_CO_YRSCALE  1.271/1.227/1.104/0.998/1.019/1.0/0.981/0.962 - 2006-2013/1/1/0 C xy 1 1
 
 #==============================================================================
 # --- QFED vertical partitioning ---
@@ -1289,7 +1288,7 @@ Mask fractions:              false
 ### END SECTION SCALE FACTORS ###
 
 ###############################################################################
-### BEGIN SECTION MASKS 
+### BEGIN SECTION MASKS
 ###############################################################################
 
 # ScalID Name sourceFile sourceVar sourceTime C/R/E SrcDim SrcUnit Oper Lon1/Lat1/Lon2/Lat2
@@ -1320,5 +1319,5 @@ Mask fractions:              false
 1109 TAGCO_BBOTH_MASK $ROOT/MASKS/v2018-09/tagged_CO_masks.generic.0.5x0.5.nc TAGCO_BBOTH_MASK 2000/1/1/0 C xy 1 1 -180/-90/180/90
 
 ### END SECTION MASKS ###
- 
+
 ### END OF HEMCO INPUT FILE ###


### PR DESCRIPTION
BCPI/BCPO emissions from Efficient Combustion Emissions in EDGAR are now included over Africa when using DICE. These were included in the original implementation but ommitted in HEMOC_Config in earlier versions of v12.