### PR TITLE
Minor typo fix for EmisNO LongName

### DIFF
--- a/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.benchmark
+++ b/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.benchmark
@@ -315,8 +315,8 @@ EmisNH3_Ship       NH3    0      10  -1   2   kg/m2/s  NH3_emission_flux_from_sh
 #####  NO emissions                                                       #####
 ###############################################################################
 EmisNO_Total       NO     -1     -1  -1   3   kg/m2/s  NO_emission_flux_from_all_sectors
-EmisNO_Aircraft    NO     0      20  -1   3   kg/m2/s  NO_emission_flux_from_anthropogenic
-EmisNO_Anthro      NO     0      1   -1   3   kg/m2/s  NO_emission_flux_from_biomass_burning
+EmisNO_Aircraft    NO     0      20  -1   3   kg/m2/s  NO_emission_flux_from_aircraft
+EmisNO_Anthro      NO     0      1   -1   3   kg/m2/s  NO_emission_flux_from_anthropogenic
 EmisNO_BioBurn     NO     111    -1  -1   2   kg/m2/s  NO_emission_flux_from_biomass_burning
 EmisNO_Lightning   NO     103    -1  -1   3   kg/m2/s  NO_emission_flux_from_lightning
 EmisNO_Ship        NO     102    -1  -1   2   kg/m2/s  NO_emission_flux_from_ships

--- a/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.non-benchmark
+++ b/runs/shared_inputs/fullchem/HEMCO_Diagn.rc.non-benchmark
@@ -315,8 +315,8 @@ EmisNH3_Ship       NH3    0      10  -1   2   kg/m2/s  NH3_emission_flux_from_sh
 #####  NO emissions                                                       #####
 ###############################################################################
 EmisNO_Total       NO     -1     -1  -1   3   kg/m2/s  NO_emission_flux_from_all_sectors
-EmisNO_Aircraft    NO     0      20  -1   3   kg/m2/s  NO_emission_flux_from_anthropogenic
-EmisNO_Anthro      NO     0      1   -1   3   kg/m2/s  NO_emission_flux_from_biomass_burning
+EmisNO_Aircraft    NO     0      20  -1   3   kg/m2/s  NO_emission_flux_from_aircraft
+EmisNO_Anthro      NO     0      1   -1   3   kg/m2/s  NO_emission_flux_from_anthropogenic
 EmisNO_BioBurn     NO     111    -1  -1   2   kg/m2/s  NO_emission_flux_from_biomass_burning
 EmisNO_Lightning   NO     103    -1  -1   3   kg/m2/s  NO_emission_flux_from_lightning
 EmisNO_Ship        NO     102    -1  -1   2   kg/m2/s  NO_emission_flux_from_ships


### PR DESCRIPTION

Fix a minor typo in three lines of the HEMCO_Diagn.rc file for EmisNO. The fix is made to the two locations that this typo appears in the geos-chem-unittest/runs/shared_inputs/ subfolders.

Signed-off-by: Tomas Sherwen <tomas.sherwen@gmail.com>