### PR TITLE
Correct typo: --dry-run should instead be --dryrun

### DIFF
--- a/runs/shared_inputs/Makefiles/Makefile
+++ b/runs/shared_inputs/Makefiles/Makefile
@@ -357,7 +357,7 @@ run:
 # Run only
 dryrun:
 	@$(MAKE) cleanup_output
-	./geos --dry-run > $(LOG_GC)
+	./geos --dryrun > $(LOG_GC)
 	@$(MAKE) printruninfo >> $(LOG_GC)
 	@$(MAKE) printruninfo
 


### PR DESCRIPTION
The typo silently causes "make dryrun" fails to enter dry run mode.